### PR TITLE
Fixes potential deadlocks in python logger

### DIFF
--- a/source/logger.cpp
+++ b/source/logger.cpp
@@ -44,28 +44,68 @@ Logger *Logger::instance()
     return &logger;
 }
 
+Logger::~Logger()
+{
+    m_stop = true;
+    m_queueCV.notify_all();
+
+    if (m_thread.joinable()) {
+        m_thread.join();
+    }
+}
+
 void Logger::addCallback(LoggerCallback &&callback, void *userData)
 {
-    std::lock_guard<std::mutex> lock(m_mutex);
+    std::lock_guard<std::mutex> lock {m_cbMutex};
     m_callbacks.emplace_back(CallbackAndData {std::move(callback), userData});
 }
 
 void Logger::clear()
 {
-    std::lock_guard<std::mutex> lock(m_mutex);
+    std::lock_guard<std::mutex> lock {m_cbMutex};
     m_callbacks.clear();
 }
 
-void Logger::log(const std::string &message, LogLevel level, const char *file, int line) const
+void Logger::log(const std::string &message, LogLevel level, const char *file, int line)
 {
-    std::lock_guard<std::mutex> lock(m_mutex);
-    for (auto &item : m_callbacks) {
-        if (item.callback) {
-            if (LIKELY(message.length() <= MAX_LOG_MESSAGE_LENGTH)) {
-                item.callback(message, level, file, line);
-            } else {
-                item.callback(cutLongString(message, MAX_LOG_MESSAGE_LENGTH), level, file, line);
+    std::lock_guard<std::mutex> lock {m_queueMutex};
+    m_queue.push(LogData {message, level, file, line});
+    m_queueCV.notify_one();
+}
+
+Logger::Logger()
+    : m_thread(&Logger::processLogs, this)
+{
+}
+
+void Logger::processLogs()
+{
+    while (!m_stop) {
+        std::unique_lock<std::mutex> queueLock {m_queueMutex};
+        m_queueCV.wait(queueLock, [this] { return !m_queue.empty() || m_stop; });
+
+        while (!m_queue.empty()) {
+            const auto logData = std::move(m_queue.front());
+            m_queue.pop();
+            queueLock.unlock(); // Unlock before calling callbacks to avoid deadlock
+
+            std::unique_lock<std::mutex> cbLock {m_cbMutex};
+            for (auto item : m_callbacks) {
+                cbLock.unlock();
+
+                if (LIKELY(item.callback)) {
+                    if (LIKELY(logData.message.length() <= MAX_LOG_MESSAGE_LENGTH)) {
+                        item.callback(logData.message, logData.level, logData.file, logData.line);
+                    } else {
+                        item.callback(cutLongString(logData.message, MAX_LOG_MESSAGE_LENGTH),
+                                      logData.level, logData.file, logData.line);
+                    }
+                }
+
+                cbLock.lock(); // Lock again for the next callback
             }
+
+            queueLock.lock(); // Lock again for the next iteration of m_queue
         }
     }
 }

--- a/source/net.h
+++ b/source/net.h
@@ -125,6 +125,7 @@ private:
     std::atomic_bool m_isGameDataInQueue {false};
     std::atomic_bool m_isHeartbeatInQueue {false};
     std::atomic_bool m_stopHeartbeatTimer {false};
+    std::atomic_bool m_stop {false};
 
     std::string m_hostname;
     std::string m_stoken;

--- a/tests/test_detail/source/test_logger.cpp
+++ b/tests/test_detail/source/test_logger.cpp
@@ -13,10 +13,12 @@
 #include <catch2/trompeloeil.hpp>
 #include <thread>
 #include <random>
+#include <chrono>
 
 // clazy:excludeall=non-pod-global-static
 
 using namespace scorbit;
+using namespace std::chrono_literals;
 
 struct CallbackHelper {
     std::string msg;
@@ -24,6 +26,11 @@ struct CallbackHelper {
     std::string fileName;
     int line;
 };
+
+inline void sleepForLogger()
+{
+    std::this_thread::sleep_for(1ms); // Give some time to the logger thread
+}
 
 TEST_CASE("logger using functor object callback")
 {
@@ -47,7 +54,8 @@ TEST_CASE("logger using functor object callback")
         // the object's data as the object will be copied
         scorbit::addLoggerCallback(std::ref(l));
         INF("Hello");
-        int line = __LINE__ - 1;
+        sleepForLogger();
+        int line = __LINE__ - 2;
         const char *file = __FILE__;
         CHECK(l.data.msg == "Hello");
         CHECK(l.data.level == scorbit::LogLevel::Info);
@@ -59,15 +67,19 @@ TEST_CASE("logger using functor object callback")
     {
         scorbit::addLoggerCallback(std::ref(l));
         DBG("Debug");
+        sleepForLogger();
         CHECK(l.data.level == scorbit::LogLevel::Debug);
 
         INF("Info");
+        sleepForLogger();
         CHECK(l.data.level == scorbit::LogLevel::Info);
 
         WRN("Warn");
+        sleepForLogger();
         CHECK(l.data.level == scorbit::LogLevel::Warn);
 
         ERR("Error");
+        sleepForLogger();
         CHECK(l.data.level == scorbit::LogLevel::Error);
     }
 
@@ -95,6 +107,7 @@ TEST_CASE("Logger with function callback using trompeloeil")
 
         scorbit::addLoggerCallback(callbackFunc);
         INF("Hello");
+        sleepForLogger();
     }
 
     resetLogger();
@@ -122,7 +135,8 @@ TEST_CASE("logger using lambda callback")
                 userData.msg = msg;
             });
     INF("Hello");
-    int line = __LINE__ - 1;
+    sleepForLogger();
+    int line = __LINE__ - 2;
     const char *file = __FILE__;
     CHECK(userData.msg == "Hello");
     CHECK(userData.level == scorbit::LogLevel::Info);
@@ -139,7 +153,8 @@ TEST_CASE("logger using bind callback")
     scorbit::addLoggerCallback(std::bind(callback, std::placeholders::_1, std::placeholders::_2,
                                       std::placeholders::_3, std::placeholders::_4, &userData));
     INF("Hello");
-    int line = __LINE__ - 1;
+    sleepForLogger();
+    int line = __LINE__ - 2;
     const char *file = __FILE__;
     CHECK(userData.msg == "Hello");
     CHECK(userData.level == scorbit::LogLevel::Info);

--- a/wrappers/python/src/game_state_py.cpp
+++ b/wrappers/python/src/game_state_py.cpp
@@ -571,10 +571,4 @@ PYBIND11_MODULE(scorbit, m)
     m.def("create_game_state", py::overload_cast<std::string, const DeviceInfo &>(&createGameState),
           py::arg("encrypted_key"), py::arg("device_info"),
           "Factory function to create a GameState instance");
-
-    // Reset the logger before exiting to prevent a SIGSEGV.
-    // Perform cleanup when the application exits:
-    // https://pybind11.readthedocs.io/en/stable/advanced/misc.html#module-destructors
-    auto atexit = py::module_::import("atexit");
-    atexit.attr("register")(py::cpp_function([]() { resetLogger(); }));
 }


### PR DESCRIPTION
- Fixes logger by preventing callback invocation during mutex lock which could lead to deadlocks.
- Modifies destructor behavior of `Logger` and `Net` classes to properly handle thread termination.
- Enhances the handling of authentication conditions within the `Net` class tasks for more robust shutdown scenarios.