### PR TITLE
Fix: build C example using Makefile

### DIFF
--- a/examples/c_example/Makefile
+++ b/examples/c_example/Makefile
@@ -1,7 +1,7 @@
 # Compiler and flags
 CC = gcc
 CFLAGS = -std=c99 -Wall -I../.. -I/usr/local/include
-LDFLAGS = -L/usr/local/lib -lscorbit_sdk -ldl
+LDFLAGS = -L/usr/local/lib -lscorbit_sdk -ldl -lrt
 
 # Source files
 SRC = main.c


### PR DESCRIPTION
Adds the `-lrt` flag to LDFLAGS in the Makefile.

This change ensures proper linking for real-time extensions used by the C example's dependencies.