### PR TITLE
Add timestamp parameter to logger

### DIFF
--- a/examples/c_example/main.c
+++ b/examples/c_example/main.c
@@ -111,19 +111,22 @@ int isUnpairTriggeredByUser(void)
 
 // This callback will be called in a thread-safe manner, so we don't worry about thread-safety
 void loggerCallback(const char *message, sb_log_level_t level, const char *file, int line,
-                    void *userData)
+                    int64_t timestamp, void *userData)
 {
     (void)userData;
     (void)file;
     (void)line;
+    (void)timestamp;
 
     // Get the current time
-    time_t ct = time(NULL);               // Current time in seconds since epoch
+    time_t ct = timestamp / 1000;      // Convert milliseconds since epoch to seconds
     struct tm *timeInfo = localtime(&ct); // Convert to local time
 
     // Buffer for formatted time string
     char timeStr[30]; // Holds a string like "2024-10-01 12:34:56"
     strftime(timeStr, sizeof(timeStr), "%Y-%m-%d %H:%M:%S", timeInfo);
+
+    int millis = timestamp % 1000; // Get milliseconds part
 
     // Determine log level string
     const char *levelStr = "UNK"; // default to unknown
@@ -146,7 +149,7 @@ void loggerCallback(const char *message, sb_log_level_t level, const char *file,
     }
 
     // Use printf to print the log message
-    printf("[%s] [%s] %s\n", timeStr, levelStr, message);
+    printf("[%s.%03d] [%s] %s\n", timeStr, millis, levelStr, message);
     fflush(stdout); // Maybe we should not flush buffer, so it will not slow down the program
 }
 

--- a/examples/cpp_example/main.cpp
+++ b/examples/cpp_example/main.cpp
@@ -106,7 +106,8 @@ bool isUnpairTriggeredByUser()
 // --------------- Example of logger callback ------------------
 
 // This callback will be called in a thread-safe manner, so we don't worry about thread-safety
-void loggerCallback(const std::string &message, scorbit::LogLevel level, const char *file, int line)
+void loggerCallback(const std::string &message, scorbit::LogLevel level, const char *file, int line,
+                    int64_t timestamp)
 {
     (void)file;
     (void)line;
@@ -116,20 +117,19 @@ void loggerCallback(const std::string &message, scorbit::LogLevel level, const c
         return;
     }
 
-    // Get current time point
-    auto now = std::chrono::system_clock::now();
+    constexpr int64_t MILLIS_IN_SECOND = 1000;
 
     // Convert to time_t for calendar time (seconds precision)
-    std::time_t t = std::chrono::system_clock::to_time_t(now);
+    std::time_t t = timestamp / MILLIS_IN_SECOND; // Convert milliseconds to seconds
 
     // Convert to milliseconds since epoch
-    auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(now.time_since_epoch()) % 1000;
+    int millis = timestamp % MILLIS_IN_SECOND; // Get milliseconds part
 
     // Format the time
     std::ostringstream oss;
     oss << std::put_time(std::localtime(&t), "%Y-%m-%d %H:%M:%S");
     // Add milliseconds
-    oss << '.' << std::setw(3) << std::setfill('0') << ms.count();
+    oss << '.' << std::setw(3) << std::setfill('0') << millis;
 
     std::cout << '[' << oss.str() << "] [";
 

--- a/examples/python_example/main.py
+++ b/examples/python_example/main.py
@@ -54,10 +54,11 @@ def is_unpair_triggered_by_user():
     return False
 
 # -------- Logger callback --------
-def logger_callback(message, level, file, line):
+def logger_callback(message, level, file, line, timestamp):
     level_str = {scorbit.LogLevel.Debug: "DBG", scorbit.LogLevel.Info: "INF",
                  scorbit.LogLevel.Warn: "WRN", scorbit.LogLevel.Error: "ERR"}.get(level, "UNK")
-    print(f"[{datetime.now().strftime('%Y-%m-%d %H:%M:%S.%f')[:-3]}] [{level_str}] {message}")
+    dt = datetime.fromtimestamp(timestamp / 1000) # timestamp is in milliseconds
+    print(f"[{dt.strftime('%Y-%m-%d %H:%M:%S.%f')[:-3]}] [{level_str}] {message}")
 
 def setup_game_state():
     info = scorbit.DeviceInfo()

--- a/include/scorbit_sdk/log.h
+++ b/include/scorbit_sdk/log.h
@@ -17,12 +17,12 @@ std::vector<scorbit::LoggerCallback *> g_callbacks;
 
 // C-style callback that forwards to the C++ function
 void cLogCallback(const char *message, sb_log_level_t level, const char *file, int line,
-                  void *user_data)
+                  int64_t timestamp, void *user_data)
 {
     auto &callback = *static_cast<scorbit::LoggerCallback *>(user_data);
     if (callback) {
         // Forward to C++ callback
-        callback(message, static_cast<scorbit::LogLevel>(level), file, line);
+        callback(message, static_cast<scorbit::LogLevel>(level), file, line, timestamp);
     }
 }
 

--- a/include/scorbit_sdk/log_types.h
+++ b/include/scorbit_sdk/log_types.h
@@ -47,8 +47,9 @@ enum class LogLevel {
  * - **line**: The line number in the source file where the log message originated.
  * - **userData**: A pointer to user-defined data, passed when registering the callback. This
  *                 can be used to maintain context or state within the callback.
+ * - **timestamp**: The timestamp of the log message in milliseconds since the epoch.
  */
 using LoggerCallback = std::function<void(const std::string &message, LogLevel level,
-                                          const char *file, int line)>;
+                                          const char *file, int line, int64_t timestamp)>;
 
 } // namespace scorbit

--- a/include/scorbit_sdk/log_types_c.h
+++ b/include/scorbit_sdk/log_types_c.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <stdint.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -46,9 +48,10 @@ typedef enum {
  * - **line**: The line number in the source file where the log message originated.
  * - **userData**: A pointer to user-defined data, passed when registering the callback. This
  *                 can be used to maintain context or state within the callback.
+ * - **timestamp**: The timestamp of the log message in millseconds since the epoch.
  */
 typedef void (*sb_log_callback_t)(const char *message, sb_log_level_t level, const char *file,
-                                  int line, void *user_data);
+                                  int line, int64_t timestamp, void *user_data);
 
 #ifdef __cplusplus
 }

--- a/source/log_c.cpp
+++ b/source/log_c.cpp
@@ -15,8 +15,9 @@ void sb_add_logger_callback(sb_log_callback_t callback, void *userData)
 
     detail::Logger::instance()->addCallback(
             [callback, userData](const std::string &message, LogLevel level, const char *file,
-                                 int line) {
-                callback(message.c_str(), static_cast<sb_log_level_t>(level), file, line, userData);
+                                 int line, int64_t timestamp) {
+                callback(message.c_str(), static_cast<sb_log_level_t>(level), file, line, timestamp,
+                         userData);
             },
             userData);
 }

--- a/source/logger.h
+++ b/source/logger.h
@@ -25,10 +25,11 @@ class Logger
     friend Logger *logger();
 
     struct LogData {
-        std::string message;
-        LogLevel level;
-        const char *file;
-        int line;
+        std::string message; // Log message
+        LogLevel level;      // Log level
+        const char *file;    // Source file name
+        int line;            // Source line number
+        int64_t timestamp;   // Timestamp in milliseconds since epoch
     };
 
     struct CallbackAndData {

--- a/tests/test_interface_c/source/test_log_c.c
+++ b/tests/test_interface_c/source/test_log_c.c
@@ -18,11 +18,12 @@ typedef struct {
 } UserData;
 
 void logCallback(const char *message, sb_log_level_t level, const char *file, int line,
-                 void *userData)
+                 int64_t timestamp, void *userData)
 {
     UserData *data = (UserData *)userData;
     data->level = level;
     data->line = line;
+    (void)timestamp;
     snprintf(data->message, sizeof(data->message), "%s", message);
     snprintf(data->file, sizeof(data->file), "%s", file);
 }

--- a/wrappers/python/src/game_state_py.cpp
+++ b/wrappers/python/src/game_state_py.cpp
@@ -96,10 +96,11 @@ PYBIND11_MODULE(scorbit, m)
     m.def(
             "add_logger_callback",
             [](py::function callback) {
-                auto safe_callback = makeSafeCallback(
-                        [callback = std::move(callback)](const std::string &message, LogLevel level,
-                                                         const char *file, int line) {
-                            callback(message, level, file, line);
+                auto safe_callback =
+                        makeSafeCallback([callback = std::move(callback)](
+                                                 const std::string &message, LogLevel level,
+                                                 const char *file, int line, int64_t timestamp) {
+                            callback(message, level, file, line, timestamp);
                         });
 
                 // Call the C++ method with our wrapped callback.


### PR DESCRIPTION
Due to the asynchronous nature of the logger, milliseconds-precision timestamps are added to logger callbacks to improve accuracy, allowing the callback to reference the exact time the log was created.