### PR TITLE
Fix segmentation fault

### DIFF
--- a/source/net.h
+++ b/source/net.h
@@ -95,7 +95,7 @@ private:
     task_t createUploadHistoryTask(const GameHistory &history);
 
     task_t createUploadTask(const std::string &endpoint, const std::string &name,
-                            const cpr::Multipart &multipart);
+                            cpr::Multipart &&multipart, std::optional<std::vector<uint8_t>> &&buffer);
 
     task_t createGetRequestTask(StringCallback replyCallback, deferred_get_setup_t deferredSetup,
                                 std::vector<AuthStatus> allowedStatuses = {


### PR DESCRIPTION
Previously, cpr::Buffer was initialized with temporary memory ranges which could lead to undefined behavior due to cpr::Buffer being a non-owning structure.

Changes:
1. Introduced a buffer std::vector to hold data for cpr::Buffer creation.
2. Updated createUploadTask method signature and lambda capture to accept/destroy moved buffers properly.
3. Added proper nullopt handling when real files are used instead of in-memory buffers.

This change prevents segmentation faults when uploading game history data.
