### PR TITLE
Refactors Worker for consistent task handling and adds SafeMultipart class

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -171,6 +171,7 @@ target_sources(
         source/player_profiles_manager.h
         source/player_profiles_manager.cpp
         source/utils/lru_cache.hpp
+        source/safe_multipart.h
 )
 
 # Generate the header from the template

--- a/include/scorbit_sdk/game_state.h
+++ b/include/scorbit_sdk/game_state.h
@@ -37,7 +37,7 @@ namespace scorbit {
  * @warning If the game is not active, all calls to modify the game state, as well as @ref commit,
  * will be ignored.
  */
-class SCORBIT_SDK_EXPORT GameState
+class GameState
 {
 public:
     GameState(sb_game_handle_t handle)

--- a/source/net.cpp
+++ b/source/net.cpp
@@ -60,7 +60,7 @@ constexpr auto HEARTBEAT_TIME = 10s;
 constexpr auto NUM_RETRIES = 3;
 
 constexpr auto MAX_BUFFER_DOWNLOAD_SIZE = 10 * 1024 * 1024; // 10 MB max size to download to memory
-constexpr auto PICTURE_BUFFER_RESERVE = 300 * 1024; // 300 KB reserve for picture download
+constexpr auto PICTURE_BUFFER_RESERVE = 300 * 1024;         // 300 KB reserve for picture download
 
 string getSignature(const SignerCallback &signer, const std::string &uuid,
                     const std::string &timestamp)
@@ -311,7 +311,7 @@ PlayerProfilesManager &Net::playersManager()
     return m_playersManager;
 }
 
-Net::task_t Net::createAuthenticateTask()
+task_t Net::createAuthenticateTask()
 {
     return [this]() {
         std::lock_guard lock(m_authMutex);
@@ -383,8 +383,8 @@ Net::task_t Net::createAuthenticateTask()
     };
 }
 
-Net::task_t Net::createInstalledTask(const std::string &type, const std::string &version,
-                                     std::optional<bool> installed, std::optional<std::string> log)
+task_t Net::createInstalledTask(const std::string &type, const std::string &version,
+                                std::optional<bool> installed, std::optional<std::string> log)
 {
     return [this, type, version, installed = std::move(installed), log = std::move(log)]() {
         for (int i = 0; i < NUM_RETRIES; ++i) {
@@ -439,7 +439,7 @@ Net::task_t Net::createInstalledTask(const std::string &type, const std::string 
     };
 }
 
-Net::task_t Net::createGameDataTask(const std::string &sessionUuid)
+task_t Net::createGameDataTask(const std::string &sessionUuid)
 {
     return [this, sessionUuid]() {
         m_isGameDataInQueue = false;
@@ -583,7 +583,7 @@ Net::task_t Net::createGameDataTask(const std::string &sessionUuid)
     };
 }
 
-Net::task_t Net::createHeartbeatTask()
+task_t Net::createHeartbeatTask()
 {
     return [this]() {
         for (int i = 0; i < NUM_RETRIES; ++i) {
@@ -693,7 +693,7 @@ void Net::postUploadHistoryTask(const GameHistory &history)
     m_worker.postQueue(createUploadHistoryTask(history));
 }
 
-Net::task_t Net::createUploadHistoryTask(const GameHistory &history)
+task_t Net::createUploadHistoryTask(const GameHistory &history)
 {
     const auto sessionUuid = history.front().sessionUuid;
     const auto filename = fmt::format("{}.csv", sessionUuid.get());
@@ -706,8 +706,8 @@ Net::task_t Net::createUploadHistoryTask(const GameHistory &history)
     return createUploadTask(SESSION_CSV_URL, filename, std::move(multipart));
 }
 
-Net::task_t Net::createUploadTask(const std::string &endpoint, const std::string &filename,
-                                  SafeMultipart &&multipart)
+task_t Net::createUploadTask(const std::string &endpoint, const std::string &filename,
+                             SafeMultipart &&multipart)
 {
     return [this, endpoint, filename, multipart = std::move(multipart)]() {
         for (int i = 0; i < NUM_RETRIES; ++i) {
@@ -738,9 +738,8 @@ Net::task_t Net::createUploadTask(const std::string &endpoint, const std::string
     };
 }
 
-Net::task_t Net::createGetRequestTask(StringCallback replyCallback,
-                                      deferred_get_setup_t deferredSetup,
-                                      std::vector<AuthStatus> allowedStatuses)
+task_t Net::createGetRequestTask(StringCallback replyCallback, deferred_get_setup_t deferredSetup,
+                                 std::vector<AuthStatus> allowedStatuses)
 {
     return [this, callback = std::move(replyCallback), deferredSetup = std::move(deferredSetup),
             allowedStatuses = std::move(allowedStatuses)]() {
@@ -795,9 +794,8 @@ Net::task_t Net::createGetRequestTask(StringCallback replyCallback,
     };
 }
 
-Net::task_t Net::createPostRequestTask(StringCallback replyCallback,
-                                       deferred_post_setup_t deferredSetup,
-                                       std::vector<AuthStatus> allowedStatuses)
+task_t Net::createPostRequestTask(StringCallback replyCallback, deferred_post_setup_t deferredSetup,
+                                  std::vector<AuthStatus> allowedStatuses)
 {
     return [this, callback = std::move(replyCallback), deferredSetup = std::move(deferredSetup),
             allowedStatuses = std::move(allowedStatuses)]() {
@@ -852,8 +850,8 @@ Net::task_t Net::createPostRequestTask(StringCallback replyCallback,
     };
 }
 
-Net::task_t Net::createDownloadFileTask(StringCallback replyCallback, std::string url,
-                                        std::string filename)
+task_t Net::createDownloadFileTask(StringCallback replyCallback, std::string url,
+                                   std::string filename)
 {
     return [callback = std::move(replyCallback), url = std::move(url),
             filename = std::move(filename)]() {
@@ -894,8 +892,8 @@ Net::task_t Net::createDownloadFileTask(StringCallback replyCallback, std::strin
     };
 }
 
-Net::task_t Net::createDownloadBufferTask(VectorCallback replyCallback, std::string url,
-                                          size_t reserveBufferSize)
+task_t Net::createDownloadBufferTask(VectorCallback replyCallback, std::string url,
+                                     size_t reserveBufferSize)
 {
     return [callback = std::move(replyCallback), url = std::move(url), reserveBufferSize]() {
         Error error {Error::ApiError};

--- a/source/net.h
+++ b/source/net.h
@@ -30,6 +30,8 @@ using SignerCallback = std::function<Signature(const Digest &digest)>;
 std::string getSignature(const SignerCallback &signer, const std::string &uuid,
                          const std::string &timestamp);
 
+class SafeMultipart;
+
 class Net : public NetBase
 {
     using task_t = std::function<void()>;
@@ -95,7 +97,7 @@ private:
     task_t createUploadHistoryTask(const GameHistory &history);
 
     task_t createUploadTask(const std::string &endpoint, const std::string &name,
-                            cpr::Multipart &&multipart, std::optional<std::vector<uint8_t>> &&buffer);
+                            SafeMultipart &&multipart);
 
     task_t createGetRequestTask(StringCallback replyCallback, deferred_get_setup_t deferredSetup,
                                 std::vector<AuthStatus> allowedStatuses = {

--- a/source/net.h
+++ b/source/net.h
@@ -34,7 +34,6 @@ class SafeMultipart;
 
 class Net : public NetBase
 {
-    using task_t = std::function<void()>;
     using deferred_get_setup_t = std::function<std::tuple<cpr::Url, cpr::Parameters>()>;
     using deferred_post_setup_t = std::function<std::tuple<cpr::Url, cpr::Payload>()>;
 

--- a/source/safe_multipart.h
+++ b/source/safe_multipart.h
@@ -1,0 +1,54 @@
+/****************************************************************************
+ *
+ * @author Dilshod Mukhtarov <dilshodm(at)gmail.com>
+ * May 2025
+ *
+ ****************************************************************************/
+
+#pragma once
+
+#include <cpr/multipart.h>
+#include <vector>
+#include <memory>
+
+namespace scorbit {
+namespace detail {
+
+/**
+ * @brief The SafeMultipart class holds a cpr::Multipart object along with associated data buffers
+ * to ensure that the data referenced by cpr::Buffer— a non-owning structure—remains valid even
+ * after the original data it pointed to has been destroyed.
+ */
+class SafeMultipart
+{
+    struct Data {
+        Data(cpr::Multipart &&multipart)
+            : multipart(std::move(multipart))
+        {
+        }
+        cpr::Multipart multipart;
+        std::vector<std::vector<char>> buffers;
+    };
+
+public:
+    explicit SafeMultipart(cpr::Multipart &&multipart)
+        : m_data(std::make_shared<Data>(std::move(multipart)))
+    {
+        for (auto &part : m_data->multipart.parts) {
+            if (part.is_buffer && part.data && part.datalen > 0) {
+                m_data->buffers.emplace_back(
+                        std::vector<char> {part.data, part.data + part.datalen});
+                part.data = m_data->buffers.back().data();
+            }
+        }
+    }
+
+    cpr::Multipart &get() { return m_data->multipart; }
+    const cpr::Multipart &get() const { return m_data->multipart; }
+
+private:
+    std::shared_ptr<Data> m_data;
+};
+
+} // namespace detail
+} // namespace scorbit

--- a/source/worker.cpp
+++ b/source/worker.cpp
@@ -41,27 +41,27 @@ void Worker::stop()
     m_running = false;
 }
 
-void Worker::post(std::function<void()> func)
+void Worker::post(task_t func)
 {
     boost::asio::post(m_ioc, std::move(func));
 }
 
-void Worker::postQueue(std::function<void()> func)
+void Worker::postQueue(task_t func)
 {
     boost::asio::post(m_strand, std::move(func));
 }
 
-void Worker::postGameDataQueue(std::function<void()> func)
+void Worker::postGameDataQueue(task_t func)
 {
     boost::asio::post(m_gameDataStrand, std::move(func));
 }
 
-void Worker::postHeartbeatQueue(std::function<void()> func)
+void Worker::postHeartbeatQueue(task_t func)
 {
     boost::asio::post(m_heartbeatStrand, std::move(func));
 }
 
-void Worker::runTimer(std::chrono::steady_clock::duration delay, std::function<void()> func)
+void Worker::runTimer(std::chrono::steady_clock::duration delay, task_t func)
 {
     m_heartbeatTimer.expires_after(delay);
     m_heartbeatTimer.async_wait([func = std::move(func)](const boost::system::error_code &ec) {

--- a/source/worker.h
+++ b/source/worker.h
@@ -17,6 +17,8 @@
 namespace scorbit {
 namespace detail {
 
+using task_t = std::function<void()>;
+
 class Worker
 {
 public:
@@ -28,12 +30,12 @@ public:
 
     bool isRunning() const { return m_running; }
 
-    void post(std::function<void()> func);
-    void postQueue(std::function<void()> func);
-    void postGameDataQueue(std::function<void()> func);
-    void postHeartbeatQueue(std::function<void()> func);
+    void post(task_t func);
+    void postQueue(task_t func);
+    void postGameDataQueue(task_t func);
+    void postHeartbeatQueue(task_t func);
 
-    void runTimer(std::chrono::steady_clock::duration delay, std::function<void()> func);
+    void runTimer(std::chrono::steady_clock::duration delay, task_t func);
 
 private:
     void run();

--- a/tests/test_detail/CMakeLists.txt
+++ b/tests/test_detail/CMakeLists.txt
@@ -119,6 +119,8 @@ target_sources(
         source/test_player_profiles_manager.cpp
         ../../source/utils/lru_cache.hpp
         source/test_lru_cache.cpp
+        ../../source/safe_multipart.h
+        source/test_safe_multipart.cpp
 )
 
 target_link_libraries(

--- a/tests/test_detail/source/test_safe_multipart.cpp
+++ b/tests/test_detail/source/test_safe_multipart.cpp
@@ -1,0 +1,86 @@
+/****************************************************************************
+ *
+ * @author Dilshod Mukhtarov <dilshodm(at)gmail.com>
+ * May 2025
+ *
+ ****************************************************************************/
+
+#include "safe_multipart.h"
+
+#include <catch2/catch_test_macros.hpp>
+#include <cstring>
+
+using namespace scorbit;
+using namespace scorbit::detail;
+
+TEST_CASE("SafeMultipart preserves buffer data", "[SafeMultipart]")
+{
+    std::string key = "file";
+    std::string original_data = "This is some test data";
+
+    cpr::Multipart multipart {
+            {key, cpr::Buffer {original_data.cbegin(), original_data.cend(), "filename.txt"}},
+    };
+
+    SafeMultipart safe_multipart(std::move(multipart));
+    cpr::Multipart &safe = safe_multipart.get();
+
+    REQUIRE(safe.parts.size() == 1);
+    const auto &part = safe.parts[0];
+
+    REQUIRE(part.is_buffer);
+    CHECK(part.name == key);
+    CHECK(part.value == "filename.txt");
+    CHECK(part.datalen == original_data.size());
+    CHECK(part.data != original_data.data()); // must not point to original string
+    CHECK(std::memcmp(part.data, original_data.data(), original_data.size()) == 0);
+
+    // Following means that it multipart doesn't point to original data
+    original_data = "another data";
+    CHECK(std::memcmp(part.data, original_data.data(), original_data.size()) != 0);
+}
+
+TEST_CASE("SafeMultipart supports move construction", "[SafeMultipart]") {
+    std::string key = "move";
+    std::string payload = "Move me!";
+
+    cpr::Multipart multipart{{key, cpr::Buffer{payload.cbegin(), payload.cend(), "movefile.txt"}}};
+    SafeMultipart original(std::move(multipart));
+
+    SafeMultipart moved(std::move(original));
+    cpr::Multipart& moved_multipart = moved.get();
+
+    REQUIRE(moved_multipart.parts.size() == 1);
+    CHECK(moved_multipart.parts[0].name == key);
+    CHECK(std::memcmp(moved_multipart.parts[0].data, payload.data(), payload.size()) == 0);
+}
+
+TEST_CASE("SafeMultipart supports move assignment", "[SafeMultipart]") {
+    std::string key = "assign";
+    std::string payload = "Assignment test";
+
+    cpr::Multipart multipart{{key, cpr::Buffer{payload.cbegin(), payload.cend(), "assign.txt"}}};
+    SafeMultipart lhs(std::move(multipart));
+
+    SafeMultipart rhs = std::move(lhs); // move assignment via initialization
+    cpr::Multipart& rhs_multipart = rhs.get();
+
+    REQUIRE(rhs_multipart.parts.size() == 1);
+    CHECK(rhs_multipart.parts[0].name == key);
+    CHECK(std::memcmp(rhs_multipart.parts[0].data, payload.data(), payload.size()) == 0);
+}
+
+TEST_CASE("SafeMultipart has shallow copy assignment", "[SafeMultipart]") {
+    std::string key = "assign";
+    std::string payload = "Assignment test";
+
+    cpr::Multipart multipart{{key, cpr::Buffer{payload.cbegin(), payload.cend(), "assign.txt"}}};
+    SafeMultipart lhs(std::move(multipart));
+
+    SafeMultipart rhs = lhs; // copy assignment
+    cpr::Multipart& rhs_multipart = rhs.get();
+
+    REQUIRE(rhs_multipart.parts.size() == 1);
+    CHECK(rhs_multipart.parts[0].name == key);
+    CHECK(rhs_multipart.parts[0].data == lhs.get().parts[0].data);
+}


### PR DESCRIPTION
- Refactors `Worker` to use `task_t` uniformly for improved readability.
- Introduces `SafeMultipart` class to ensure safe handling of `cpr::Multipart` with non-owning structure cpr::Buffer.
- Removes unnecessary export symbols from the GameState wrapper to remove c++ class dependency from shared library. 