### PR TITLE
Updater: if provider uses encrypted key, make sure that SDK was built as prod (by scorbit)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,8 +2,11 @@ cmake_minimum_required(VERSION 3.28)
 
 # Read version from VERSION file
 if(NOT DEFINED SCORBIT_SDK_VERSION)
-    set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS
-                 "${CMAKE_CURRENT_SOURCE_DIR}/VERSION")
+    set_property(
+        DIRECTORY
+        APPEND
+        PROPERTY CMAKE_CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/VERSION"
+    )
     file(READ "${CMAKE_CURRENT_SOURCE_DIR}/VERSION" SCORBIT_SDK_VERSION)
     string(STRIP "${SCORBIT_SDK_VERSION}" SCORBIT_SDK_VERSION)
 endif()
@@ -68,7 +71,7 @@ set(CMAKE_INSTALL_RPATH $ORIGIN $ORIGIN/${relDir})
 
 # To silence warning in PackageProject
 if(POLICY CMP0177)
-  set(CMAKE_POLICY_DEFAULT_CMP0177 NEW)
+    set(CMAKE_POLICY_DEFAULT_CMP0177 NEW)
 endif()
 # PackageProject.cmake will be used to make our target installable
 CPMAddPackage("gh:TheLartians/PackageProject.cmake@1.13.0")
@@ -179,11 +182,7 @@ target_sources(
 )
 
 # Generate the header from the template
-configure_file(
-    source/platform_id.h.in
-    "${CMAKE_CURRENT_BINARY_DIR}/platform_id.h"
-    @ONLY
-)
+configure_file(source/platform_id.h.in "${CMAKE_CURRENT_BINARY_DIR}/platform_id.h" @ONLY)
 
 # being a cross-platform target, we enforce standards conformance on MSVC
 target_compile_options(${PROJECT_NAME} PUBLIC "$<$<COMPILE_LANG_AND_ID:CXX,MSVC>:/permissive->")
@@ -238,7 +237,6 @@ if(SCORBIT_SDK_ABI STREQUAL "u12")
 endif()
 
 # Detect architecture
-
 
 # Set package file name to include architecture
 set(CPACK_PACKAGE_FILE_NAME "${PROJECT_NAME}-${PROJECT_VERSION}-${SCORBIT_SDK_PLATFORM_ID}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -214,7 +214,10 @@ target_include_directories(
 include(cmake/encrypt.cmake)
 target_compile_definitions(
     ${PROJECT_NAME}
-    PRIVATE SCORBIT_SDK_ENCRYPT_SECRET="${SCORBIT_SDK_ENCRYPT_SECRET}"
+    PRIVATE
+        SCORBIT_SDK_ENCRYPT_SECRET="${SCORBIT_SDK_ENCRYPT_SECRET}"
+        SCORBIT_SDK_THIS_KEY_HASH="${SCORBIT_SDK_THIS_KEY_HASH}"
+        SCORBIT_SDK_PRODUCTION_KEY_HASH="${SCORBIT_SDK_PRODUCTION_KEY_HASH}"
 )
 
 # ---- Create an installable target ----

--- a/cmake/ArchDetect.cmake
+++ b/cmake/ArchDetect.cmake
@@ -39,11 +39,7 @@ function(get_target_arch OUT_VAR)
             OUTPUT_STRIP_TRAILING_WHITESPACE
         )
     elseif(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
-        execute_process(
-            COMMAND ${CMAKE_CXX_COMPILER}
-            ERROR_VARIABLE RAW_ARCH
-            OUTPUT_QUIET
-        )
+        execute_process(COMMAND ${CMAKE_CXX_COMPILER} ERROR_VARIABLE RAW_ARCH OUTPUT_QUIET)
 
         # Parse from string like "for x64" or "for x86"
         string(REGEX MATCH "for ([^ \n]+)" MATCH_RESULT "${RAW_ARCH}")

--- a/cmake/encrypt.cmake
+++ b/cmake/encrypt.cmake
@@ -9,12 +9,17 @@
 
 set(SCORBIT_SDK_ENCRYPT_SECRET "$ENV{SCORBIT_SDK_ENCRYPT_SECRET}")
 
+set(SCORBIT_SDK_PRODUCTION_KEY_HASH
+    "0f06680dec68958ce55a3c5fa47fc37a138aa30cd6dd52b379277dd81ec5d9dc"
+)
+
 # Read the SCORBIT_SDK_ENCRYPT_SECRET environment variable for production build
 if(SCORBIT_SDK_PRODUCTION)
     message(STATUS "Production build")
-    string(SHA256 SCORBIT_SDK_HASH "$ENV{SCORBIT_SDK_ENCRYPT_SECRET}")
-    if(NOT SCORBIT_SDK_HASH STREQUAL "0f06680dec68958ce55a3c5fa47fc37a138aa30cd6dd52b379277dd81ec5d9dc")
-        message(FATAL_ERROR
+    string(SHA256 SCORBIT_SDK_THIS_KEY_HASH "$ENV{SCORBIT_SDK_ENCRYPT_SECRET}")
+    if(NOT SCORBIT_SDK_THIS_KEY_HASH STREQUAL SCORBIT_SDK_PRODUCTION_KEY_HASH)
+        message(
+            FATAL_ERROR
             "SCORBIT_SDK_ENCRYPT_SECRET [$ENV{SCORBIT_SDK_ENCRYPT_SECRET}] is incorrect for production build!"
             " If this is not production build, run cmake with -D SCORBIT_SDK_PRODUCTION=OFF"
         )

--- a/cmake/tools.cmake
+++ b/cmake/tools.cmake
@@ -3,7 +3,7 @@
 
 # only activate tools for top level project
 if(NOT PROJECT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
-  return()
+    return()
 endif()
 
 # Build with /MD in MSVC
@@ -12,7 +12,7 @@ if(MSVC AND NOT DEFINED CMAKE_MSVC_RUNTIME_LIBRARY)
 endif()
 
 if(MSVC)
-  add_definitions(-D_WIN32_WINNT=0x0601)
+    add_definitions(-D_WIN32_WINNT=0x0601)
 endif()
 
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
@@ -22,64 +22,46 @@ include(${CMAKE_CURRENT_LIST_DIR}/CPM.cmake)
 # enables sanitizers support using the the `USE_SANITIZER` flag available values are: Address,
 # Memory, MemoryWithOrigins, Undefined, Thread, Leak, 'Address;Undefined'
 if(USE_SANITIZER OR USE_STATIC_ANALYZER)
-  CPMAddPackage("gh:StableCoder/cmake-scripts#24.08.1")
+    CPMAddPackage("gh:StableCoder/cmake-scripts#24.08.1")
 
-  if(USE_SANITIZER)
-    include(${cmake-scripts_SOURCE_DIR}/sanitizers.cmake)
-  endif()
-
-  if(USE_STATIC_ANALYZER)
-    if("clang-tidy" IN_LIST USE_STATIC_ANALYZER)
-      set(CLANG_TIDY
-          ON
-          CACHE INTERNAL ""
-      )
-    else()
-      set(CLANG_TIDY
-          OFF
-          CACHE INTERNAL ""
-      )
-    endif()
-    if("iwyu" IN_LIST USE_STATIC_ANALYZER)
-      set(IWYU
-          ON
-          CACHE INTERNAL ""
-      )
-    else()
-      set(IWYU
-          OFF
-          CACHE INTERNAL ""
-      )
-    endif()
-    if("cppcheck" IN_LIST USE_STATIC_ANALYZER)
-      set(CPPCHECK
-          ON
-          CACHE INTERNAL ""
-      )
-    else()
-      set(CPPCHECK
-          OFF
-          CACHE INTERNAL ""
-      )
+    if(USE_SANITIZER)
+        include(${cmake-scripts_SOURCE_DIR}/sanitizers.cmake)
     endif()
 
-    include(${cmake-scripts_SOURCE_DIR}/tools.cmake)
+    if(USE_STATIC_ANALYZER)
+        if("clang-tidy" IN_LIST USE_STATIC_ANALYZER)
+            set(CLANG_TIDY ON CACHE INTERNAL "")
+        else()
+            set(CLANG_TIDY OFF CACHE INTERNAL "")
+        endif()
+        if("iwyu" IN_LIST USE_STATIC_ANALYZER)
+            set(IWYU ON CACHE INTERNAL "")
+        else()
+            set(IWYU OFF CACHE INTERNAL "")
+        endif()
+        if("cppcheck" IN_LIST USE_STATIC_ANALYZER)
+            set(CPPCHECK ON CACHE INTERNAL "")
+        else()
+            set(CPPCHECK OFF CACHE INTERNAL "")
+        endif()
 
-    if(${CLANG_TIDY})
-      clang_tidy(${CLANG_TIDY_ARGS})
-    endif()
+        include(${cmake-scripts_SOURCE_DIR}/tools.cmake)
 
-    if(${IWYU})
-      include_what_you_use(${IWYU_ARGS})
-    endif()
+        if(${CLANG_TIDY})
+            clang_tidy(${CLANG_TIDY_ARGS})
+        endif()
 
-    if(${CPPCHECK})
-      cppcheck(${CPPCHECK_ARGS})
+        if(${IWYU})
+            include_what_you_use(${IWYU_ARGS})
+        endif()
+
+        if(${CPPCHECK})
+            cppcheck(${CPPCHECK_ARGS})
+        endif()
     endif()
-  endif()
 endif()
 
 # enables CCACHE support through the USE_CCACHE flag possible values are: YES, NO or equivalent
 if(USE_CCACHE)
-  CPMAddPackage("gh:TheLartians/Ccache.cmake@1.2.5")
+    CPMAddPackage("gh:TheLartians/Ccache.cmake@1.2.5")
 endif()

--- a/encrypt_tool/CMakeLists.txt
+++ b/encrypt_tool/CMakeLists.txt
@@ -55,10 +55,7 @@ set_target_properties(
 
 target_sources(${PROJECT_NAME} PRIVATE source/main.cpp)
 
-target_include_directories(
-    ${PROJECT_NAME}
-    PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../3rd/obfuscate
-)
+target_include_directories(${PROJECT_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../3rd/obfuscate)
 
 # being a cross-platform target, we enforce standards conformance on MSVC
 target_compile_options(${PROJECT_NAME} PUBLIC "$<$<COMPILE_LANG_AND_ID:CXX,MSVC>:/permissive->")
@@ -84,10 +81,7 @@ if(UNIX AND NOT APPLE)
     target_link_libraries(${PROJECT_NAME} PRIVATE dl)
 endif()
 
-install(
-    TARGETS ${PROJECT_NAME}
-    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
-)
+install(TARGETS ${PROJECT_NAME} RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
 
 # ---- Create an installable target ----
 # this allows users to install and find the library via `find_package()`.

--- a/encrypt_tool/source/main.cpp
+++ b/encrypt_tool/source/main.cpp
@@ -128,9 +128,8 @@ int main(int argc, char *argv[])
 
     try {
         const auto secret = hex2bytes(argv[1]);
-        std::string provider = argv[2] + std::string(AY_OBFUSCATE(SCORBIT_SDK_ENCRYPT_SECRET));
-
-        std::string encrypted = encryptSecret(secret, provider);
+        std::string encrypted = encryptSecret(
+                secret, argv[2] + std::string(AY_OBFUSCATE(SCORBIT_SDK_ENCRYPT_SECRET)));
         std::cout << encrypted << std::endl;
     } catch (std::exception &e) {
         std::cerr << e.what() << std::endl;

--- a/examples/c_example/CMakeLists.txt
+++ b/examples/c_example/CMakeLists.txt
@@ -7,7 +7,7 @@
 # The above copyright notice and this permission notice shall be included in
 # all copies or substantial portions of the Software.
 
-    cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.16)
 
 project(c_example LANGUAGES C)
 
@@ -23,8 +23,5 @@ else()
     CPMAddPackage(NAME scorbit_sdk SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}/../..)
 endif()
 
-add_executable(
-    ${PROJECT_NAME}
-    main.c
-)
+add_executable(${PROJECT_NAME} main.c)
 target_link_libraries(${PROJECT_NAME} PRIVATE scorbit_sdk::scorbit_sdk)

--- a/examples/cpp_example/CMakeLists.txt
+++ b/examples/cpp_example/CMakeLists.txt
@@ -26,8 +26,5 @@ else()
     CPMAddPackage(NAME scorbit_sdk SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}/../..)
 endif()
 
-add_executable(
-    ${PROJECT_NAME}
-    main.cpp
-)
+add_executable(${PROJECT_NAME} main.cpp)
 target_link_libraries(${PROJECT_NAME} PRIVATE scorbit_sdk::scorbit_sdk)

--- a/scripts/u12-build.sh
+++ b/scripts/u12-build.sh
@@ -10,7 +10,6 @@
 # all copies or substantial portions of the Software.
 
 REL=6
-SCORBIT_SDK_ABI=u12
 
 set -e
 
@@ -23,9 +22,12 @@ VERSION=$(get_version "$SCRIPT_DIR/../VERSION")
 run_build() {
     ARCH=$1
     PLATFORM=$2
+    SCORBIT_SDK_ABI=$3
+    RELEASE=$4
 
-    DOCKER_IMAGE=dilshodm/ubuntu-builder-$ARCH:12.04_${REL} #-devel
+    DOCKER_IMAGE=dilshodm/ubuntu-builder-$ARCH:12.04_${RELEASE}
     build_using_docker "$ARCH" "$PLATFORM" "$VERSION" "$SCORBIT_SDK_ABI" "$DOCKER_IMAGE"
 }
 
-run_build arm linux/arm/v7
+run_build arm linux/arm/v7 u12 6
+run_build arm linux/arm/v7 u12dev 6-devel

--- a/source/game_state_c.cpp
+++ b/source/game_state_c.cpp
@@ -51,11 +51,9 @@ GameStateImpl createGameStateImpl(std::string encryptedKey, const DeviceInfo &de
                    provider = deviceInfo.provider](const Digest &digest) {
         Signature signature;
 
-        auto decrypted = decryptSecret(
+        const auto key = decryptSecret(
                 encryptedKey, provider + std::string(AY_OBFUSCATE(SCORBIT_SDK_ENCRYPT_SECRET)));
-        if (!decrypted.empty()) {
-            const auto key = decryptSecret(encryptedKey, provider + SCORBIT_SDK_ENCRYPT_SECRET);
-
+        if (!key.empty()) {
             const auto result = Signer::sign(signature, digest, key);
             if (result != SignErrorCode::Ok) {
                 ERR(std::string {AY_OBFUSCATE("Failed to sign the digest. Error: {}")},

--- a/source/game_state_c.cpp
+++ b/source/game_state_c.cpp
@@ -39,9 +39,10 @@ struct sb_game_state_struct {
 
 namespace {
 
-GameStateImpl createGameStateImpl(SignerCallback signer, const DeviceInfo &deviceInfo)
+GameStateImpl createGameStateImpl(SignerCallback signer, const DeviceInfo &deviceInfo,
+                                  bool useEncryptedKey)
 {
-    auto net = std::make_unique<Net>(std::move(signer), deviceInfo);
+    auto net = std::make_unique<Net>(std::move(signer), deviceInfo, useEncryptedKey);
     return GameStateImpl(std::move(net));
 }
 
@@ -64,7 +65,7 @@ GameStateImpl createGameStateImpl(std::string encryptedKey, const DeviceInfo &de
         return signature;
     };
 
-    return createGameStateImpl(std::move(signer), deviceInfo);
+    return createGameStateImpl(std::move(signer), deviceInfo, true);
 }
 
 }
@@ -83,7 +84,8 @@ sb_game_handle_t sb_create_game_state(sb_signer_callback_t signer, void *signer_
         return signature;
     };
 
-    return new sb_game_state_struct {createGameStateImpl(std::move(cb), DeviceInfo(*device_info))};
+    return new sb_game_state_struct {
+            createGameStateImpl(std::move(cb), DeviceInfo(*device_info), false)};
 }
 
 sb_game_handle_t sb_create_game_state2(const char *encrypted_key,

--- a/source/net.cpp
+++ b/source/net.cpp
@@ -95,10 +95,10 @@ string getSignature(const SignerCallback &signer, const std::string &uuid,
 
 // --------------------------------------------------------------------------------
 
-Net::Net(SignerCallback signer, DeviceInfo deviceInfo)
+Net::Net(SignerCallback signer, DeviceInfo deviceInfo, bool useEncryptedKey)
     : m_signer(std::move(signer))
     , m_deviceInfo(std::move(deviceInfo))
-    , m_updater(*this)
+    , m_updater(*this, useEncryptedKey)
 {
     setHostname(m_deviceInfo.hostname);
 

--- a/source/net.h
+++ b/source/net.h
@@ -63,7 +63,7 @@ class Net : public NetBase
     };
 
 public:
-    Net(SignerCallback signer, DeviceInfo deviceInfo);
+    Net(SignerCallback signer, DeviceInfo deviceInfo, bool useEncryptedKey);
     ~Net() override;
 
     AuthStatus status() const override;

--- a/source/updater.h
+++ b/source/updater.h
@@ -30,7 +30,7 @@ namespace detail {
 class Updater
 {
 public:
-    Updater(NetBase &net);
+    Updater(NetBase &net, bool useEncryptedKey);
 
     void checkNewVersionAndUpdate(const boost::json::object &json);
 
@@ -42,6 +42,8 @@ private:
 private:
     NetBase &m_net;
     std::atomic_bool m_updateInProgress {false};
+
+    const bool m_useEncryptedKey;
 
     std::string m_url;
     std::string m_version;

--- a/tests/test_detail/CMakeLists.txt
+++ b/tests/test_detail/CMakeLists.txt
@@ -54,7 +54,7 @@ find_package(LibArchive REQUIRED) # Try to find system-installed libarchive
 
 # Boost -----------
 
-set(BOOST_COMPILED_COMPONENTS filesystem json thread )
+set(BOOST_COMPILED_COMPONENTS filesystem json thread)
 set(BOOST_HEADER_ONLY_COMPONENTS asio uuid flyweight dll)
 include(${CMAKE_CURRENT_LIST_DIR}/../../cmake/boost.cmake)
 
@@ -62,10 +62,7 @@ include(${CMAKE_CURRENT_LIST_DIR}/../../cmake/boost.cmake)
 if(TEST_INSTALLED_VERSION)
     find_package(scorbit_sdk REQUIRED)
 else()
-    CPMAddPackage(
-        NAME scorbit_sdk
-        SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}/../..
-    )
+    CPMAddPackage(NAME scorbit_sdk SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}/../..)
 endif()
 
 find_package(OpenSSL REQUIRED)
@@ -145,7 +142,8 @@ if(UNIX AND NOT APPLE)
     target_link_libraries(${PROJECT_NAME} PRIVATE dl)
 endif()
 
-target_include_directories(${PROJECT_NAME}
+target_include_directories(
+    ${PROJECT_NAME}
     PRIVATE
         "${CMAKE_CURRENT_SOURCE_DIR}/source"
         "${scorbit_sdk_SOURCE_DIR}/include"
@@ -172,10 +170,12 @@ target_compile_definitions(
         SCORBIT_SDK_STATIC_DEFINE=1
 )
 
-if (WIN32)
-    add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
-        COMMAND ${CMAKE_COMMAND} -E copy_if_different
-            $<TARGET_FILE:scorbit_sdk>
+if(WIN32)
+    add_custom_command(
+        TARGET ${PROJECT_NAME}
+        POST_BUILD
+        COMMAND
+            ${CMAKE_COMMAND} -E copy_if_different $<TARGET_FILE:scorbit_sdk>
             $<TARGET_FILE_DIR:${PROJECT_NAME}>
     )
 endif()

--- a/tests/test_detail/source/test_net.cpp
+++ b/tests/test_detail/source/test_net.cpp
@@ -42,7 +42,7 @@ TEST_CASE("Net constructor")
 {
     ALLOW_CALL(Signer, signer(_)).RETURN(Signature {});
     DeviceInfo info;
-    Net net {signer, std::move(info)};
+    Net net {signer, std::move(info), true};
 }
 
 TEST_CASE("Net hostname")
@@ -50,7 +50,7 @@ TEST_CASE("Net hostname")
     ALLOW_CALL(Signer, signer(_)).RETURN(Signature {});
 
     DeviceInfo info;
-    Net net {signer, std::move(info)};
+    Net net {signer, std::move(info), true};
     CHECK(net.hostname() == "https://api.scorbit.io:443"); // By default it's production
 
     net.setHostname("production");

--- a/wrappers/python/CMakeLists.txt
+++ b/wrappers/python/CMakeLists.txt
@@ -49,18 +49,26 @@ target_link_libraries(scorbit PRIVATE scorbit_sdk::scorbit_sdk)
 execute_process(
     COMMAND ${Python_EXECUTABLE} -m pybind11_stubgen --help
     RESULT_VARIABLE STUBGEN_EXIT_CODE
-    OUTPUT_QUIET ERROR_QUIET
+    OUTPUT_QUIET
+    ERROR_QUIET
 )
 
 # Only add the command if pybind11-stubgen is available
 if(STUBGEN_EXIT_CODE EQUAL 0)
     add_custom_command(
-        TARGET scorbit POST_BUILD
-        COMMAND ${Python_EXECUTABLE} -m pybind11_stubgen scorbit -o ${CMAKE_CURRENT_BINARY_DIR}/stubs
+        TARGET scorbit
+        POST_BUILD
+        COMMAND
+            ${Python_EXECUTABLE} -m pybind11_stubgen scorbit -o ${CMAKE_CURRENT_BINARY_DIR}/stubs
         COMMENT "Generating stubs using pybind11-stubgen"
     )
     # Install the generated stubs
-    install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/stubs/ DESTINATION scorbit FILES_MATCHING PATTERN "*")
+    install(
+        DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/stubs/
+        DESTINATION scorbit
+        FILES_MATCHING
+        PATTERN "*"
+    )
 else()
     message(WARNING "pybind11-stubgen not found, skipping stub generation.")
 endif()
@@ -72,4 +80,3 @@ install(
     ARCHIVE DESTINATION scorbit
     RUNTIME DESTINATION scorbit
 )
-


### PR DESCRIPTION
If SDK was built by provider then their encrypted key can't be decrypted by SDK which was built by Scorbit. In this case SDK should skip update.