### PR TITLE
Adjust score metadata

### DIFF
--- a/source/identifiers.h
+++ b/source/identifiers.h
@@ -107,8 +107,10 @@ constexpr auto JKEY_SCR_METADATA {"metadata"};
 constexpr auto JKEY_SCR_GAME {"game"};
 constexpr auto JKEY_SCR_MACHINE {"machine"};
 constexpr auto JKEY_SCR_VARIANT {"variant"};
+constexpr auto JKEY_SCR_VENUE {"venue"};
 constexpr auto JKEY_SCR_SEQUENCE {"sequence"};
-constexpr auto JKEY_SCR_TIMESTAMP {"timestamp"};
+constexpr auto JKEY_SCR_CREATED_AT {"created_at"};
+constexpr auto JKEY_SCR_UPDATED_AT {"updated_at"};
 
 constexpr auto JVAL_SCR_SCORE_UPDATE {"score_update"};
 constexpr auto JVAL_SCR_GAME_END {"game_end"};

--- a/source/identifiers.h
+++ b/source/identifiers.h
@@ -119,6 +119,7 @@ constexpr auto JKEY_SCFG_SHORTCODE {"shortcode"};
 constexpr auto JKEY_SCFG_MACHINE_UUID {"machine_id"};
 constexpr auto JKEY_SCFG_MACHINE_ID {"machine_id"};
 constexpr auto JKEY_SCFG_VARIANT_ID {"variant_id"};
+constexpr auto JKEY_SCFG_VENUE_ID {"venue_id"};
 constexpr auto JKEY_SCFG_CONFIG {"config"};
 constexpr auto JKEY_SCFG_OPDB_ID {"opdb_id"};
 constexpr auto JKEY_SCFG_SCORBITRON_MACHINE {"machine"};

--- a/source/net.cpp
+++ b/source/net.cpp
@@ -283,7 +283,8 @@ void Net::sendGameData(const detail::GameData &data, bool isGameJustFinished)
         // TODO: check if it's needed to lock mutex here
         const auto sessionCounter = ++gameSession->sessionCounter;
         const auto modes = json::parse(gameData.modes.jsonStr());
-        const auto currentDateTime = to_iso8601(chrono::system_clock::now());
+        const auto updatedAt = to_iso8601(chrono::system_clock::now());
+        const auto createdAt = to_iso8601(gameSession->startedSystemTime);
 
         json::array_t scores;
         for (const auto &[playerNum, playerState] : gameData.players) {
@@ -314,16 +315,22 @@ void Net::sendGameData(const detail::GameData &data, bool isGameJustFinished)
 
         json j {{JKEY_CHN_TYPE, valType},
                 {JKEY_CHN_PAYLOAD,
-                 {{JKEY_SCR_GAME_IN_PROGRESS, data.isGameActive},
-                  {keyScores, scores},
-                  {JKEY_SCR_METADATA,
-                   {
-                           {JKEY_SCR_GAME, sessionUuid},
-                           {JKEY_SCR_MACHINE, m_machineInfo.machineUuid},
-                           {JKEY_SCR_VARIANT, m_machineInfo.variantUuid},
-                           {JKEY_SCR_SEQUENCE, sessionCounter},
-                           {JKEY_SCR_TIMESTAMP, currentDateTime},
-                   }}}}};
+                 {
+                         {JKEY_SCR_GAME_IN_PROGRESS, data.isGameActive},
+                         {keyScores, scores},
+                 }},
+                {JKEY_SCR_METADATA,
+                 {
+                         {JKEY_SCR_GAME, sessionUuid},
+                         {JKEY_SCR_MACHINE, m_machineInfo.machineUuid},
+                         {JKEY_SCR_VARIANT, m_machineInfo.variantUuid},
+                         {JKEY_SCR_VENUE, m_machineInfo.venueUuid.empty()
+                                                  ? json(nullptr)
+                                                  : json(m_machineInfo.venueUuid)},
+                         {JKEY_SCR_SEQUENCE, sessionCounter},
+                         {JKEY_SCR_CREATED_AT, createdAt},
+                         {JKEY_SCR_UPDATED_AT, updatedAt},
+                 }}};
 
         const auto jstr = j.dump();
         INF("API sending game data to channel: {}, data: {}", m_machineChannel, jstr);

--- a/source/net.cpp
+++ b/source/net.cpp
@@ -392,6 +392,11 @@ void Net::getConfig()
                         it->get_to(m_machineInfo.variantUuid);
                     }
 
+                    if (const auto it = json.find(JKEY_SCFG_VENUE_ID);
+                        it != json.end() && it->is_string()) {
+                        it->get_to(m_machineInfo.venueUuid);
+                    }
+
                     if (const auto configIt = json.find(JKEY_SCFG_CONFIG);
                         configIt != json.end() && configIt->is_object()) {
                         if (const auto it = configIt->find(JKEY_SCFG_OPDB_ID);

--- a/source/net.h
+++ b/source/net.h
@@ -74,6 +74,7 @@ class Net : public NetBase
         std::string opdbId;
         std::string machineUuid;
         std::string variantUuid;
+        std::string venueUuid;
     };
 
 public:

--- a/source/net.h
+++ b/source/net.h
@@ -66,6 +66,8 @@ class Net : public NetBase
         GameData gameData;
         std::chrono::time_point<std::chrono::steady_clock> startedTime {
                 std::chrono::steady_clock::now()};
+        std::chrono::time_point<std::chrono::system_clock> startedSystemTime {
+                std::chrono::system_clock::now()};
         GameHistory history;
         std::unordered_map<sb_player_t, ScoreMetadata> scoresMetadata;
     };


### PR DESCRIPTION
Adjust score metada: move it outside of payload. 
Updated metadata fields: created_at, updated_at and venue