### PR TITLE
Fix: build issue when running cmake twice without CPM_SOURCE_CACHE

### DIFF
--- a/cmake/lib_cpr.cmake
+++ b/cmake/lib_cpr.cmake
@@ -5,6 +5,14 @@ else()
     unset(CURL_LIBRARIES)
 endif()
 
+set(cpr_PATCH_FILE "${CMAKE_CURRENT_SOURCE_DIR}/patches/cpr-gcc-9.3-build-fix.patch")
+
+# Use CPMAddPackages patches option only if CPM_SOURCE_CACHE is defined
+# Otherwise it will fail on the second cmake run
+if(CPM_SOURCE_CACHE)
+    set(cpr_PATCHES_OPTION PATCHES "${cpr_PATCH_FILE}")
+endif()
+
 CPMAddPackage(
     NAME cpr
     GIT_TAG 1.12.0
@@ -12,31 +20,15 @@ CPMAddPackage(
     EXCLUDE_FROM_ALL YES
     SYSTEM YES
     GIT_SHALLOW TRUE
+    ${cpr_PATCHES_OPTION}
     OPTIONS "BUILD_SHARED_LIBS OFF" "BUILD_CPR_TESTS OFF" "${CPR_OPTIONS}"
 )
 
-if(cpr_ADDED)
-    set(CPR_SOURCE_DIR ${cpr_SOURCE_DIR})
-
-    execute_process(
-        COMMAND git apply --check "${CMAKE_CURRENT_SOURCE_DIR}/patches/cpr-gcc-9.3-build-fix.patch"
-        WORKING_DIRECTORY ${CPR_SOURCE_DIR}
-        RESULT_VARIABLE patch_check_result
-        OUTPUT_QUIET
-        ERROR_QUIET
+# If the patches option is not defined, apply the patch manually
+if(NOT DEFINED cpr_PATCHES_OPTION)
+    include(${CMAKE_SOURCE_DIR}/cmake/patch.cmake)
+    apply_patch(
+        "${CMAKE_CURRENT_SOURCE_DIR}/patches/cpr-gcc-9.3-build-fix.patch"
+        "${cpr_SOURCE_DIR}"
     )
-
-    if(patch_check_result EQUAL 0)
-        message(STATUS "Applying CPR patch...")
-        execute_process(
-            COMMAND git apply "${CMAKE_CURRENT_SOURCE_DIR}/patches/cpr-gcc-9.3-build-fix.patch"
-            WORKING_DIRECTORY ${CPR_SOURCE_DIR}
-            RESULT_VARIABLE patch_result
-        )
-        if(NOT patch_result EQUAL 0)
-            message(FATAL_ERROR "Failed to apply patch to CPR")
-        endif()
-    else()
-        message(STATUS "CPR patch already applied (skipping).")
-    endif()
 endif()

--- a/cmake/patch.cmake
+++ b/cmake/patch.cmake
@@ -1,0 +1,25 @@
+function(apply_patch PATCH_FILE SOURCE_DIR)
+    # Check if patch can be applied
+    execute_process(
+        COMMAND git apply --check "${PATCH_FILE}"
+        WORKING_DIRECTORY "${SOURCE_DIR}"
+        RESULT_VARIABLE patch_check_result
+        OUTPUT_QUIET
+        ERROR_QUIET
+    )
+
+    if(patch_check_result EQUAL 0)
+        message(STATUS "Applying patch: ${PATCH_FILE}")
+        execute_process(
+            COMMAND git apply "${PATCH_FILE}"
+            WORKING_DIRECTORY "${SOURCE_DIR}"
+            RESULT_VARIABLE patch_result
+        )
+        if(NOT patch_result EQUAL 0)
+            message(FATAL_ERROR "Failed to apply patch: ${PATCH_FILE}")
+        endif()
+    else()
+        message(STATUS "Patch already applied or not applicable: ${PATCH_FILE}")
+    endif()
+endfunction()
+


### PR DESCRIPTION
1. If CPM_SOURCE_CACHE defined then we can use CPM's PATCHES option, so it will not warning as dirty cache
2. If it's not defined, we patch manually, otherwise on second cmake run, CPM will try to patch again and will fail
