### PR TITLE
Skip NFC nonce creation if no NFC tap pad available

### DIFF
--- a/libs/spb/include/spb/probes_manager.h
+++ b/libs/spb/include/spb/probes_manager.h
@@ -41,7 +41,7 @@ class ProbesManager
 public:
     ProbesManager() = default;
 
-    auto enumerate(ProbeType probesSet, const ProbeDisplayCallback &callback = nullptr) -> void;
+    auto enumerate(probe_t probesSet, const ProbeDisplayCallback &callback = nullptr) -> void;
 
     auto cpu() const -> ProbeCPU * { return m_cpu.get(); }
     auto dmd() const -> ProbeDMD * { return m_dmd.get(); }

--- a/libs/spb/source/probes_manager.cpp
+++ b/libs/spb/source/probes_manager.cpp
@@ -19,12 +19,12 @@ constexpr auto NFC_PROBE_ID = "NFC";
 constexpr int NFC_SESSION_BRIGHTNESS = 0;
 constexpr int NFC_IDLE_BRIGHTNESS = 30;
 
-static bool has_flag(ProbeType probesSet, ProbeType flag)
+static bool has_flag(probe_t probesSet, ProbeType flag)
 {
     return static_cast<probe_t>(probesSet) & static_cast<probe_t>(flag);
 }
 
-void ProbesManager::enumerate(ProbeType probesSet, const ProbeDisplayCallback &callback)
+void ProbesManager::enumerate(probe_t probesSet, const ProbeDisplayCallback &callback)
 {
     // INF("Enumerating probes...");
 

--- a/source/net.cpp
+++ b/source/net.cpp
@@ -1543,6 +1543,10 @@ void Net::updateScorbitronConfig()
 
 void Net::createNfcNonces()
 {
+    if (!m_deviceInfo.nfcCapable) {
+        return;
+    }
+
     m_worker.postQueue(createPostRequestTask(
             [this](Error error, std::string reply) {
                 if (error == Error::Success) {


### PR DESCRIPTION
The network layer now skips the NFC nonce creation step on devices that report no NFC support. By guarding the request post‑queue with a capability check, apps can run on hardware‑restricted or older devices without triggering errors or unnecessary network traffic.

Additionally, the probes manager was updated to use the correct bitmask type when enumerating probes, eliminating type‑mismatch warnings and ensuring accurate probe selection.