### PR TITLE
fix(build): handle missing artifacts in docker build script

### DIFF
--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -73,9 +73,14 @@ build_using_docker() {
     cleanup_build_files "$BUILD_DIR" || true
     docker_build "$CMD" "$DOCKER_IMAGE"
 
-    # Move artifacts to dist directory
+    # Move artifacts to dist directory (.deb omitted when cpack DEB was skipped — no dpkg-deb)
     mkdir -p "$DIST_DIR"
-    mv $BUILD_DIR/*.deb $BUILD_DIR/*.tar.gz $BUILD_DIR/encrypt_tool/*.tar.gz $DIST_DIR
+    shopt -s nullglob
+    artifacts=("$BUILD_DIR"/*.deb "$BUILD_DIR"/*.tar.gz "$BUILD_DIR"/encrypt_tool/*.tar.gz)
+    shopt -u nullglob
+    if ((${#artifacts[@]})); then
+        mv "${artifacts[@]}" "$DIST_DIR"
+    fi
 }
 
 # Example usage (only runs when sourced interactively)


### PR DESCRIPTION
Update the build script to use nullglob when moving artifacts to the distribution directory. This prevents the script from failing when specific files, such as .deb packages, are not generated.
