### PR TITLE
feat: allow bidirectional u18 and u20 platform matching

### DIFF
--- a/source/updater.cpp
+++ b/source/updater.cpp
@@ -62,12 +62,6 @@ fs::path findFile(const fs::path &dir, const std::regex &pattern)
     return {};
 }
 
-bool endsWith(const std::string &str, const std::string &suffix)
-{
-    return str.size() >= suffix.size()
-        && str.compare(str.size() - suffix.size(), suffix.size(), suffix) == 0;
-}
-
 } // namespace
 
 namespace scorbit {
@@ -195,17 +189,13 @@ Updater::UrlInfo Updater::parseUrls(const nlohmann::json &obj) const
                 }
 
                 const auto platformId = match[3].str();
-                // To transition from u20 to u18
-                const auto u18Equivalent = std::invoke([this]() {
-                    if (endsWith(m_scorbitdPlatformId, "u20")) {
-                        // If our platform ends with u20, accept u18 as a fallback
-                        return m_scorbitdPlatformId.substr(0, m_scorbitdPlatformId.size() - 3)
-                             + "u18";
-                    }
-                    return std::string {};
-                });
-                if (platformId == m_scorbitdPlatformId
-                    || (!u18Equivalent.empty() && platformId == u18Equivalent)) {
+                // To transition between u20 <=> u18
+                const auto u18Equivalent =
+                        m_scorbitdPlatformId.substr(0, m_scorbitdPlatformId.size() - 3) + "u18";
+                const auto u20Equivalent =
+                        m_scorbitdPlatformId.substr(0, m_scorbitdPlatformId.size() - 3) + "u20";
+                if (platformId == m_scorbitdPlatformId || platformId == u18Equivalent
+                    || platformId == u20Equivalent) {
                     asset["download_url"].get_to(info.url);
                     asset["content_type"].get_to(info.contentType);
                     asset["size"].get_to(info.size);


### PR DESCRIPTION
Update the updater's URL parsing logic to support transitions between u18 and u20 platform identifiers in both directions.
