### PR TITLE
fix: ensure credit status wait for connection and machine ID

### DIFF
--- a/source/net.cpp
+++ b/source/net.cpp
@@ -1630,15 +1630,14 @@ void Net::sendScorbitronObject()
 {
     m_worker.post(createPatchRequestTask(
             [this](Error error, std::string reply) {
-                parseScorbitronObject(error, reply);
                 if (error == Error::Success) {
                     INF("API initial Scorbitron object sent: ok, {}", reply);
-                    parseScorbitronObject(error, reply);
                 } else {
                     ERR("API initial Scorbitron object sent: failed, error code: {}, "
                         "reply: {}",
                         static_cast<int>(error), reply);
                 }
+                parseScorbitronObject(error, reply);
             },
             [this]() {
                 std::string body;
@@ -1825,6 +1824,7 @@ void Net::parseScorbitronObject(Error error, const std::string &reply)
                     idIt != it->end() && idIt->is_string()) {
                     idIt->get_to(m_machineInfo.machineUuid);
                     m_machineChannel = fmt::format("machine:{}", m_machineInfo.machineUuid);
+                    requestCreditsStatusIfReady();
                 }
             }
         }
@@ -2263,7 +2263,7 @@ void Net::centrifugoSetup()
         }
 
         INF("API-CF Connected to Centrifugo!");
-        requestCreditsStatusEvent();
+        requestCreditsStatusIfReady();
     });
 
     m_centrifugo->onDisconnected([this](centrifugo::Error const &error) {
@@ -2493,6 +2493,17 @@ void Net::checkNfcBootReason()
 void Net::requestCreditsStatusEvent()
 {
     m_eventManager->push(std::make_shared<CreditsStatusRequestedEvent>());
+}
+
+void Net::requestCreditsStatusIfReady()
+{
+    if (m_stop || !m_centrifugo || m_machineChannel.empty()) {
+        return;
+    }
+    if (m_centrifugo->state() != centrifugo::ConnectionState::Connected) {
+        return;
+    }
+    requestCreditsStatusEvent();
 }
 
 void Net::requestFirmwaresList()

--- a/source/net.h
+++ b/source/net.h
@@ -228,6 +228,10 @@ private:
     void checkNfcBootReason();
 
     void requestCreditsStatusEvent();
+    /// Request credits status from the app only when Centrifugo is connected and
+    /// `m_machineChannel` is set (must match a server-side subscription from the JWT).
+    void requestCreditsStatusIfReady();
+
     void requestFirmwaresList();
 
     void checkSystemTimeAccuracy(int64_t timestamp) const;


### PR DESCRIPTION
Introduces `requestCreditsStatusIfReady` to gate credit status requests until the Centrifugo connection is established and the machine UUID (required for the machine channel) has been received and parsed. This prevents premature requests during the initialization sequence.
