### PR TITLE
feat: lower scheduling priority for background threads

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -207,6 +207,8 @@ target_sources(
         source/utils/machine_fingerprint.cpp
         source/utils/decrypt.h
         source/utils/decrypt.cpp
+        source/utils/thread_priority.h
+        source/utils/thread_priority.cpp
 
         source/utils/date_time_parser.h
         source/utils/date_time_parser.cpp

--- a/libs/logger/logger_callback/logger_callback.cpp
+++ b/libs/logger/logger_callback/logger_callback.cpp
@@ -27,6 +27,14 @@
 #include <variant>
 #include <vector>
 
+#if defined(__linux__)
+#    include <sys/resource.h>
+#    include <sys/syscall.h>
+#    include <unistd.h>
+#elif defined(__APPLE__)
+#    include <pthread.h>
+#endif
+
 namespace {
 
 #if defined(__GNUC__) || defined(__clang__)
@@ -104,8 +112,20 @@ private:
     {
     }
 
+    static void lowerThreadPriority()
+    {
+#if defined(__linux__)
+        const pid_t tid = static_cast<pid_t>(syscall(SYS_gettid));
+        setpriority(PRIO_PROCESS, static_cast<id_t>(tid), 10);
+#elif defined(__APPLE__)
+        pthread_set_qos_class_self_np(QOS_CLASS_BACKGROUND, 0);
+#endif
+    }
+
     void processLogs()
     {
+        lowerThreadPriority();
+
         for (;;) {
             LogQueueItem item;
             m_queue.wait_dequeue(item);

--- a/source/game_state_c.cpp
+++ b/source/game_state_c.cpp
@@ -29,6 +29,7 @@
 #include "signer_key_resolver.h"
 #include "nfc_tpm_key_resolver.h"
 #include "soft_key_resolver.h"
+#include "utils/thread_priority.h"
 #include <logger/logger.h>
 #include <blockingconcurrentqueue.h>
 #include <string>
@@ -337,6 +338,8 @@ sb_game_state_struct::~sb_game_state_struct()
 
 void sb_game_state_struct::cApiDispatcherLoop()
 {
+    scorbit::detail::lowerCurrentThreadPriority();
+
     for (;;) {
         ApiQueueItem item;
         cApiQueue.wait_dequeue(item);

--- a/source/utils/thread_priority.cpp
+++ b/source/utils/thread_priority.cpp
@@ -1,0 +1,60 @@
+/*
+ * Scorbit SDK
+ *
+ * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scrobit.io, All Rights Reserved
+ *
+ * MIT License
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include "thread_priority.h"
+
+#if defined(__linux__)
+#    include <sys/resource.h>
+#    include <sys/syscall.h>
+#    include <unistd.h>
+#    include <cerrno>
+#elif defined(__APPLE__)
+#    include <pthread.h>
+#endif
+
+namespace scorbit {
+namespace detail {
+
+// Nice value applied to every SDK-owned thread.  Higher values = lower priority.
+// 10 is well below interactive/real-time work while still getting reasonable CPU
+// time for network I/O and bookkeeping.
+static constexpr int SDK_THREAD_NICE_VALUE = 10;
+
+void lowerCurrentThreadPriority()
+{
+#if defined(__linux__)
+    // setpriority with PRIO_PROCESS and tid==0 would affect the whole process on
+    // some glibc versions.  Use the raw syscall with the Linux thread-id instead
+    // so only the calling thread is re-niced.
+    const pid_t tid = static_cast<pid_t>(syscall(SYS_gettid));
+    if (setpriority(PRIO_PROCESS, static_cast<id_t>(tid), SDK_THREAD_NICE_VALUE) != 0) {
+        // Best-effort; ignore EACCES (may lack CAP_SYS_NICE)
+    }
+#elif defined(__APPLE__)
+    (void)SDK_THREAD_NICE_VALUE;
+    // macOS doesn't have per-thread nice values exposed via setpriority.
+    // QOS_CLASS_BACKGROUND is the lowest non-maintenance class.
+    pthread_set_qos_class_self_np(QOS_CLASS_BACKGROUND, 0);
+#else
+    // No-op on unsupported platforms (Windows, etc.)
+#endif
+}
+
+} // namespace detail
+} // namespace scorbit

--- a/source/utils/thread_priority.h
+++ b/source/utils/thread_priority.h
@@ -1,0 +1,31 @@
+/*
+ * Scorbit SDK
+ *
+ * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scrobit.io, All Rights Reserved
+ *
+ * MIT License
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#pragma once
+
+namespace scorbit {
+namespace detail {
+
+// Lowers the calling thread's scheduling priority so SDK background work
+// does not starve latency-sensitive application threads (e.g. audio callbacks).
+// On Linux this sets a positive nice value; on other platforms it is a no-op.
+void lowerCurrentThreadPriority();
+
+} // namespace detail
+} // namespace scorbit

--- a/source/worker.cpp
+++ b/source/worker.cpp
@@ -18,6 +18,7 @@
  */
 
 #include "worker.h"
+#include "utils/thread_priority.h"
 #include <logger/logger.h>
 
 constexpr auto NUM_OF_THREADS = 4;
@@ -94,7 +95,10 @@ void Worker::start()
 
     m_running = true;
     for (int i = 0; i < NUM_OF_THREADS; ++i) {
-        m_threads.create_thread([this] { m_ioc.run(); });
+        m_threads.create_thread([this] {
+            lowerCurrentThreadPriority();
+            m_ioc.run();
+        });
     }
 }
 

--- a/tests/test_detail/CMakeLists.txt
+++ b/tests/test_detail/CMakeLists.txt
@@ -107,6 +107,8 @@ target_sources(
         source/test_net_util.cpp
         ../../source/worker.cpp
         ../../source/worker.h
+        ../../source/utils/thread_priority.h
+        ../../source/utils/thread_priority.cpp
         source/test_worker.cpp
         ../../source/utils/mac_address.h
         ../../source/utils/mac_address.cpp


### PR DESCRIPTION
Reduces the scheduling priority for SDK-managed threads (logging, workers, and network discovery) on Linux and macOS. This ensures that background bookkeeping and I/O tasks do not starve latency-sensitive application threads, such as audio callbacks or game engine loops.
