### PR TITLE
feat: make background thread priority configurable

### DIFF
--- a/examples/c_example/main.c
+++ b/examples/c_example/main.c
@@ -367,6 +367,11 @@ sb_game_handle_t setup_game_state(void)
     sb_config_set_score_features(config, G_SCORE_FEATURES, G_SCORE_FEATURES_COUNT,
                                  G_SCORE_FEATURES_VERSION);
 
+    // Optional: sb_config_set_threads_priority(). If you omit this call or pass 0, the SDK does not
+    // change scheduling for its background threads (default). Use a positive value (e.g. 10) on
+    // Linux to renice those threads lower.
+    // sb_config_set_threads_priority(config, 10);
+
     // Provider's encrypted private key (generated using encrypt_tool).
     // Used for V2 provisioning authentication to prove provider identity.
     sb_config_set_encrypted_key(

--- a/examples/cpp_example/main.cpp
+++ b/examples/cpp_example/main.cpp
@@ -315,6 +315,12 @@ scorbit::GameState setupGameState()
             .setHostname("staging")
             .setAutoDownloadPlayerPics(true)
             .setScoreFeatures(G_SCORE_FEATURES, G_SCORE_FEATURES_VERSION)
+
+            // Optional: .setThreadsPriority(n) - omit or use 0 for no change to SDK background
+            // thread scheduling; use a positive value (e.g. 10) on Linux to lower CPU priority of
+            // those threads
+            // .setThreadsPriority(10)
+
             // Provider's encrypted private key (generated using encrypt_tool).
             // Used for V2 provisioning authentication to prove provider identity.
             .setEncryptedKey(

--- a/examples/python27_example/main.py
+++ b/examples/python27_example/main.py
@@ -206,6 +206,10 @@ def setup_game_state():
     config.set_auto_download_player_pics(True)
     config.set_score_features(G_SCORE_FEATURES, G_SCORE_FEATURES_VERSION)
 
+    # Optional: set_threads_priority(). If omitted or set to 0, the SDK does not change scheduling
+    # for its background threads. Use a positive value (e.g. 10) on Linux to renice those threads.
+    # config.set_threads_priority(10)
+
     config.set_encrypted_key('8qWNpMPeO1AbgcoPSsdeUORGmO/hyB70oyrpFyRlYWbaVx4Kuan0CAGaXZWS3JWdgmPL7p9k3UFTwAp5y16L8O1tYaHLGkW4p/yWmA==')
 
     config.set_save_key_callback(save_key_callback)

--- a/examples/python_example/main.py
+++ b/examples/python_example/main.py
@@ -176,6 +176,10 @@ def setup_game_state():
     config.set_auto_download_player_pics(True)
     config.set_score_features(G_SCORE_FEATURES, G_SCORE_FEATURES_VERSION)
 
+    # Optional: set_threads_priority(). If omitted or set to 0, the SDK does not change scheduling
+    # for its background threads. Use a positive value (e.g. 10) on Linux to renice those threads.
+    # config.set_threads_priority(10)
+
     config.set_encrypted_key('8qWNpMPeO1AbgcoPSsdeUORGmO/hyB70oyrpFyRlYWbaVx4Kuan0CAGaXZWS3JWdgmPL7p9k3UFTwAp5y16L8O1tYaHLGkW4p/yWmA==')
 
     config.set_save_key_callback(save_key_callback)

--- a/include/scorbit_sdk/config.h
+++ b/include/scorbit_sdk/config.h
@@ -50,7 +50,8 @@ using EventCallback = std::function<void(const Event &event)>;
  * auto gameState = scorbit::createGameState(encryptedKey, config);
  * @endcode
  */
-class Config {
+class Config
+{
 public:
     /**
      * @brief Construct a new Config object with default values.
@@ -161,6 +162,15 @@ public:
     Config &setAutoDownloadPlayerPics(bool enable)
     {
         sb_config_set_auto_download_player_pics(m_handle.get(), enable);
+        return *this;
+    }
+
+    /**
+     * @brief Set nice / QOS for SDK background threads (see @ref sb_config_set_threads_priority).
+     */
+    Config &setThreadsPriority(int priority)
+    {
+        sb_config_set_threads_priority(m_handle.get(), priority);
         return *this;
     }
 

--- a/include/scorbit_sdk/config_c.h
+++ b/include/scorbit_sdk/config_c.h
@@ -129,6 +129,24 @@ SCORBIT_SDK_EXPORT
 void sb_config_set_auto_download_player_pics(sb_config_t config, bool enable);
 
 /**
+ * @brief Set scheduling priority for SDK-owned background threads (worker and C API queue).
+ *
+ * On Linux this is the value passed to setpriority(2) for each of those threads (higher means
+ * lower CPU priority relative to the process baseline). The default is 0, which leaves thread
+ * scheduling unchanged (legacy behavior). Set a positive value (for example 10) to deprioritize
+ * SDK work versus latency-sensitive threads such as audio callbacks.
+ *
+ * On macOS, any non-zero value requests QOS_CLASS_BACKGROUND for those threads; 0 leaves them
+ * unchanged.
+ *
+ * @param config The configuration handle.
+ * @param priority Nice value on Linux; 0 disables adjustment. Must be set before @ref
+ * sb_create_game_state.
+ */
+SCORBIT_SDK_EXPORT
+void sb_config_set_threads_priority(sb_config_t config, int priority);
+
+/**
  * @brief Set score features.
  *
  * Score features help identify what triggered a score increase (e.g., ramp, spinner, target).

--- a/source/config_c.cpp
+++ b/source/config_c.cpp
@@ -87,6 +87,13 @@ void sb_config_set_auto_download_player_pics(sb_config_t config, bool enable)
     }
 }
 
+void sb_config_set_threads_priority(sb_config_t config, int priority)
+{
+    if (config) {
+        config->threadsNice = priority;
+    }
+}
+
 void sb_config_set_score_features(sb_config_t config, const char **features, size_t count,
                                   int version)
 {

--- a/source/device_info.h
+++ b/source/device_info.h
@@ -51,6 +51,9 @@ struct DeviceInfo {
     std::vector<std::string> scoreFeatures;
     int scoreFeaturesVersion {0};
 
+    /// Per-thread nice for SDK worker threads (Linux setpriority); 0 = do not adjust.
+    int threadsNice {0};
+
     // Authentication - one of these must be set
     std::string encryptedKey;
     sb_signer_callback_t signerCallback {nullptr};

--- a/source/game_state_c.cpp
+++ b/source/game_state_c.cpp
@@ -338,7 +338,7 @@ sb_game_state_struct::~sb_game_state_struct()
 
 void sb_game_state_struct::cApiDispatcherLoop()
 {
-    scorbit::detail::lowerCurrentThreadPriority();
+    scorbit::detail::applySdkThreadNice(gameState.configuredSdkThreadsNice());
 
     for (;;) {
         ApiQueueItem item;

--- a/source/game_state_impl.h
+++ b/source/game_state_impl.h
@@ -64,6 +64,9 @@ public:
 
     AuthStatus getStatus() const;
 
+    /** Nice / thread scheduling value from config (see @ref sb_config_set_threads_priority). */
+    int configuredSdkThreadsNice() const { return m_net->deviceInfo().threadsNice; }
+
     const std::string &getMachineUuid() const;
     std::uint64_t getMachineSerial() const;
     const std::string &getPairDeeplink() const;

--- a/source/net.cpp
+++ b/source/net.cpp
@@ -162,6 +162,7 @@ Net::Net(DeviceInfo deviceInfo, std::vector<std::unique_ptr<IKeyResolver>> resol
     , m_deviceInfo(std::move(deviceInfo))
     , m_updater(*this, m_deviceInfo.usesEncryptedKey(), m_deviceInfo.scorbitdVersion,
                 m_deviceInfo.scorbitdPlatformId)
+    , m_worker(m_deviceInfo.threadsNice)
     , m_eventManager(std::make_shared<EventManager>(m_worker.eventsStrand(),
                                                     std::move(m_deviceInfo.m_eventCallback)))
 {

--- a/source/utils/thread_priority.cpp
+++ b/source/utils/thread_priority.cpp
@@ -31,27 +31,28 @@
 namespace scorbit {
 namespace detail {
 
-// Nice value applied to every SDK-owned thread.  Higher values = lower priority.
-// 10 is well below interactive/real-time work while still getting reasonable CPU
-// time for network I/O and bookkeeping.
-static constexpr int SDK_THREAD_NICE_VALUE = 10;
-
-void lowerCurrentThreadPriority()
+void applySdkThreadNice(int niceValue)
 {
 #if defined(__linux__)
+    if (niceValue == 0) {
+        return;
+    }
     // setpriority with PRIO_PROCESS and tid==0 would affect the whole process on
     // some glibc versions.  Use the raw syscall with the Linux thread-id instead
     // so only the calling thread is re-niced.
     const pid_t tid = static_cast<pid_t>(syscall(SYS_gettid));
-    if (setpriority(PRIO_PROCESS, static_cast<id_t>(tid), SDK_THREAD_NICE_VALUE) != 0) {
+    if (setpriority(PRIO_PROCESS, static_cast<id_t>(tid), niceValue) != 0) {
         // Best-effort; ignore EACCES (may lack CAP_SYS_NICE)
     }
 #elif defined(__APPLE__)
-    (void)SDK_THREAD_NICE_VALUE;
+    if (niceValue == 0) {
+        return;
+    }
     // macOS doesn't have per-thread nice values exposed via setpriority.
     // QOS_CLASS_BACKGROUND is the lowest non-maintenance class.
     pthread_set_qos_class_self_np(QOS_CLASS_BACKGROUND, 0);
 #else
+    (void)niceValue;
     // No-op on unsupported platforms (Windows, etc.)
 #endif
 }

--- a/source/utils/thread_priority.h
+++ b/source/utils/thread_priority.h
@@ -22,10 +22,12 @@
 namespace scorbit {
 namespace detail {
 
-// Lowers the calling thread's scheduling priority so SDK background work
-// does not starve latency-sensitive application threads (e.g. audio callbacks).
-// On Linux this sets a positive nice value; on other platforms it is a no-op.
-void lowerCurrentThreadPriority();
+// Adjusts the calling thread's scheduling priority for SDK background work.
+// @param niceValue On Linux, passed to setpriority(2) for this thread only; higher values mean
+//        lower CPU priority. If 0, scheduling is left unchanged (default).
+//        On macOS, any non-zero value selects QOS_CLASS_BACKGROUND for this thread; 0 leaves it
+//        unchanged. Unsupported platforms ignore this call.
+void applySdkThreadNice(int niceValue);
 
 } // namespace detail
 } // namespace scorbit

--- a/source/worker.cpp
+++ b/source/worker.cpp
@@ -67,8 +67,9 @@ struct fmt::formatter<Worker::Timer> : fmt::formatter<std::string_view> {
 namespace scorbit {
 namespace detail {
 
-Worker::Worker()
-    : m_timers {{
+Worker::Worker(int threadNiceValue)
+    : m_threadNiceValue(threadNiceValue)
+    , m_timers {{
               boost::asio::steady_timer {m_ioc},
               boost::asio::steady_timer {m_ioc},
               boost::asio::steady_timer {m_ioc},
@@ -96,7 +97,7 @@ void Worker::start()
     m_running = true;
     for (int i = 0; i < NUM_OF_THREADS; ++i) {
         m_threads.create_thread([this] {
-            lowerCurrentThreadPriority();
+            applySdkThreadNice(m_threadNiceValue);
             m_ioc.run();
         });
     }

--- a/source/worker.h
+++ b/source/worker.h
@@ -51,7 +51,8 @@ public:
     };
 
 public:
-    Worker();
+    /// @param threadNiceValue Linux nice passed to setpriority for each worker thread; 0 disables.
+    explicit Worker(int threadNiceValue = 0);
     ~Worker();
 
     void start();
@@ -81,6 +82,7 @@ private:
     using asio_strand = boost::asio::strand<boost::asio::io_context::executor_type>;
 
     std::atomic_bool m_running {false};
+    int m_threadNiceValue {0};
 
     boost::asio::io_context m_ioc;
     boost::asio::executor_work_guard<boost::asio::io_context::executor_type> m_workGuard {

--- a/tests/test_interface/source/test_device_info.cpp
+++ b/tests/test_interface/source/test_device_info.cpp
@@ -97,6 +97,12 @@ TEST_CASE("sb_config_t setters", "[Config][C]")
         sb_config_set_auto_download_player_pics(config, false);
     }
 
+    SECTION("Set threads_priority")
+    {
+        sb_config_set_threads_priority(config, 0);
+        sb_config_set_threads_priority(config, 10);
+    }
+
     SECTION("Set score_features")
     {
         const char *features[] = {"ramp", "spinner", "target"};
@@ -126,6 +132,7 @@ TEST_CASE("sb_config_t null safety", "[Config][C]")
     sb_config_set_uuid(nullptr, "uuid");
     sb_config_set_serial_number(nullptr, 123);
     sb_config_set_auto_download_player_pics(nullptr, true);
+    sb_config_set_threads_priority(nullptr, 10);
     sb_config_set_score_features(nullptr, nullptr, 0, 0);
     sb_config_set_encrypted_key(nullptr, "key");
 }
@@ -152,6 +159,7 @@ TEST_CASE("Config method chaining", "[Config][C++]")
             .setUuid("f0b188f8-9f2d-4f8d-abe4-c3107516e7ce")
             .setSerialNumber(123456789)
             .setAutoDownloadPlayerPics(true)
+            .setThreadsPriority(10)
             .setScoreFeatures({"ramp", "spinner", "target"}, 1)
             .setEncryptedKey("encrypted_key_data");
 
@@ -214,6 +222,13 @@ TEST_CASE("Config setters", "[Config][C++]")
     {
         config.setAutoDownloadPlayerPics(true);
         config.setAutoDownloadPlayerPics(false);
+        REQUIRE(config.isValid());
+    }
+
+    SECTION("Set threads_priority")
+    {
+        config.setThreadsPriority(0);
+        config.setThreadsPriority(10);
         REQUIRE(config.isValid());
     }
 

--- a/wrappers/python/src/scorbit/_bindings.py
+++ b/wrappers/python/src/scorbit/_bindings.py
@@ -133,6 +133,10 @@ _lib.sb_config_set_serial_number.argtypes = [sb_config_t, c_uint64]
 _lib.sb_config_set_auto_download_player_pics.restype = None
 _lib.sb_config_set_auto_download_player_pics.argtypes = [sb_config_t, c_bool]
 
+# void sb_config_set_threads_priority(sb_config_t, int)
+_lib.sb_config_set_threads_priority.restype = None
+_lib.sb_config_set_threads_priority.argtypes = [sb_config_t, c_int]
+
 # void sb_config_set_score_features(sb_config_t, const char**, size_t, int)
 _lib.sb_config_set_score_features.restype = None
 _lib.sb_config_set_score_features.argtypes = [

--- a/wrappers/python/src/scorbit/config.py
+++ b/wrappers/python/src/scorbit/config.py
@@ -171,6 +171,12 @@ class Config(object):
         _lib.sb_config_set_auto_download_player_pics(self._handle, enable)
         return self
 
+    def set_threads_priority(self, priority):
+        # type: (int) -> Config
+        """Nice / QOS for SDK background threads; ``0`` leaves scheduling unchanged (default)."""
+        _lib.sb_config_set_threads_priority(self._handle, priority)
+        return self
+
     def set_score_features(self, features, version=1):
         # type: (list[str], int) -> Config
         """Set score features that identify what triggered a score increase.

--- a/wrappers/python27/src/scorbit/_bindings.py
+++ b/wrappers/python27/src/scorbit/_bindings.py
@@ -135,6 +135,10 @@ _lib.sb_config_set_serial_number.argtypes = [sb_config_t, c_uint64]
 _lib.sb_config_set_auto_download_player_pics.restype = None
 _lib.sb_config_set_auto_download_player_pics.argtypes = [sb_config_t, c_bool]
 
+# void sb_config_set_threads_priority(sb_config_t, int)
+_lib.sb_config_set_threads_priority.restype = None
+_lib.sb_config_set_threads_priority.argtypes = [sb_config_t, c_int]
+
 # void sb_config_set_score_features(sb_config_t, const char**, size_t, int)
 _lib.sb_config_set_score_features.restype = None
 _lib.sb_config_set_score_features.argtypes = [

--- a/wrappers/python27/src/scorbit/config.py
+++ b/wrappers/python27/src/scorbit/config.py
@@ -176,6 +176,12 @@ class Config(object):
         _lib.sb_config_set_auto_download_player_pics(self._handle, enable)
         return self
 
+    def set_threads_priority(self, priority):
+        # type: (int) -> Config
+        """Nice / QOS for SDK background threads; ``0`` leaves scheduling unchanged (default)."""
+        _lib.sb_config_set_threads_priority(self._handle, priority)
+        return self
+
     def set_score_features(self, features, version=1):
         # type: (list, int) -> Config
         """Set score features that identify what triggered a score increase.


### PR DESCRIPTION
Provides a new configuration option to set the scheduling priority (nice value) for SDK worker threads. This replaces the hardcoded priority adjustment with a user-tunable setting, allowing developers to balance background SDK work against latency-sensitive application tasks like audio processing.
