### PR TITLE
feat: add pricing received event and structured pricing API

### DIFF
--- a/examples/c_example/main.c
+++ b/examples/c_example/main.c
@@ -332,17 +332,32 @@ void eventsCallback(const sb_event_t *event, void *user_data)
         }
     } break;
 
+    case SB_EVT_PRICING_RECEIVED: {
+        bool free_play = false;
+        sb_event_pricing_free_play(event, &free_play);
+        printf("Pricing received: free_play=%s\n", free_play ? "true" : "false");
+
+        const char *price = NULL;
+        if (sb_event_pricing_credit_price(event, &price)) {
+            printf("  Credit price: %s\n", price);
+        }
+
+        int count = 0;
+        sb_event_pricing_bundles_count(event, &count);
+        for (int i = 0; i < count; ++i) {
+            int credits = 0;
+            const char *bundle_price = NULL;
+            sb_event_pricing_bundle_credits(event, i, &credits);
+            sb_event_pricing_bundle_price(event, i, &bundle_price);
+            printf("  Bundle: %d credits for %s\n", credits, bundle_price ? bundle_price : "N/A");
+        }
+    } break;
+
     // -------- OEM providers can ignore the events below, they are mostly for scorbitron ----------
     case SB_EVT_CONFIG_RECEIVED: {
         const char *config_json = NULL;
         if (sb_event_config_received(event, &config_json)) {
             printf("Config received: %s\n", config_json ? config_json : "NULL");
-            // Process the config JSON string here or copy it for further use
-        }
-
-        bool payments_enabled = false;
-        if (sb_event_config_payments_enabled(event, &payments_enabled)) {
-            printf("Payments enabled: %s\n", payments_enabled ? "true" : "false");
         }
     } break;
 

--- a/examples/cpp_example/main.cpp
+++ b/examples/cpp_example/main.cpp
@@ -283,20 +283,31 @@ void eventsCallback(const scorbit::Event &event)
         }
     } break;
 
+    case scorbit::EventType::PricingReceived: {
+        scorbit::PricingInfo pricing;
+        if (event.getPricingReceived(pricing)) {
+            cout << "Pricing received: free_play=" << pricing.freePlay << endl;
+            if (!pricing.creditPrice.empty()) {
+                cout << "  Credit price: " << pricing.creditPrice
+                     << " (regular: " << pricing.creditRegularPrice << ")" << endl;
+                if (!pricing.creditSalePrice.empty()) {
+                    cout << "  Credit sale price: " << pricing.creditSalePrice << endl;
+                }
+            }
+            for (const auto &bundle : pricing.bundles) {
+                cout << "  Bundle: " << bundle.credits << " credits for " << bundle.price << endl;
+            }
+        }
+    } break;
+
         // ----- OEM providers can ignore the events below, they are mostly for scorbitron ------
 
     case scorbit::EventType::ConfigReceived: {
         std::string configJson;
         if (event.eventConfigReceived(configJson)) {
             cout << "Config received: " << configJson << endl;
-            // Process config JSON ...
         } else {
             cout << "Error getting config event" << endl;
-        }
-
-        bool paymentsEnabled = false;
-        if (event.getConfigPaymentsEnabled(paymentsEnabled)) {
-            cout << "Payments enabled: " << (paymentsEnabled ? "true" : "false") << endl;
         }
     } break;
 

--- a/examples/python27_example/main.py
+++ b/examples/python27_example/main.py
@@ -160,14 +160,21 @@ def events_callback(event):
         if success is not None:
             print("Diagnostics upload %s" % ("succeeded" if success else "failed"))
 
+    elif event.type == scorbit.EventType.PricingReceived:
+        pricing = event.get_pricing_received()
+        if pricing is not None:
+            print("Pricing received: free_play=%s" % pricing.free_play)
+            if pricing.credit_price:
+                print("  Credit price: %s (regular: %s)" % (pricing.credit_price, pricing.credit_regular_price))
+                if pricing.credit_sale_price:
+                    print("  Credit sale price: %s" % pricing.credit_sale_price)
+            for bundle in pricing.bundles:
+                print("  Bundle: %d credits for %s" % (bundle.credits, bundle.price))
+
     elif event.type == scorbit.EventType.ConfigReceived:
         config_json = event.get_config_received()
         if config_json is not None:
             print("Config received: %s" % config_json)
-
-        payments_enabled = event.get_config_payments_enabled()
-        if payments_enabled is not None:
-            print("Payments enabled: %s" % payments_enabled)
 
 def _pair_code_cb(error, short_code):
     if error == scorbit.Error.Success:

--- a/examples/python_example/main.py
+++ b/examples/python_example/main.py
@@ -144,6 +144,17 @@ def events_callback(event):
             player_num, picture = result
             print(f"Player {player_num} picture ready: {len(picture)} bytes")
 
+    elif event.type == scorbit.EventType.PricingReceived:
+        pricing = event.get_pricing_received()
+        if pricing is not None:
+            print(f"Pricing received: free_play={pricing.free_play}")
+            if pricing.credit_price:
+                print(f"  Credit price: {pricing.credit_price} (regular: {pricing.credit_regular_price})")
+                if pricing.credit_sale_price:
+                    print(f"  Credit sale price: {pricing.credit_sale_price}")
+            for bundle in pricing.bundles:
+                print(f"  Bundle: {bundle.credits} credits for {bundle.price}")
+
     elif event.type == scorbit.EventType.DiagnosticsUploadRequested:
         include_recordings = event.get_diagnostics_upload_requested()
         if include_recordings is not None:
@@ -162,10 +173,6 @@ def events_callback(event):
         config_json = event.get_config_received()
         if config_json is not None:
             print(f"Config received: {config_json}")
-
-        payments_enabled = event.get_config_payments_enabled()
-        if payments_enabled is not None:
-            print(f"Payments enabled: {payments_enabled}")
 
 def setup_game_state():
     config = scorbit.Config()

--- a/include/scorbit_sdk/event.h
+++ b/include/scorbit_sdk/event.h
@@ -9,6 +9,7 @@
 
 #include "event_types.h"
 #include "player_info.h"
+#include "pricing_info.h"
 #include <scorbit_sdk/event_helpers_c.h>
 #include <string>
 #include <map>
@@ -70,21 +71,53 @@ public:
     }
 
     /**
-     * @brief Helper function to extract payments enabled status from a
-     * @ref scorbit::Type::ConfigReceived event.
+     * @brief Helper function to process a pricing received event.
      *
-     * This function extracts the payments_enabled field from a config received event.
-     * The event type must be @ref scorbit::EventType::ConfigReceived, otherwise the function
-     * returns an error.
+     * Populates a @ref PricingInfo struct with free_play, payments_enabled, credit prices,
+     * and bundle data from the event.
      *
-     * @param paymentsEnabled [OUT] A reference to a bool that will receive the payments enabled
-     * value.
-     * @return Returns true on success, or false if an error occurs (e.g., wrong event type was
-     * given).
+     * The event type must be @ref scorbit::EventType::PricingReceived, otherwise the function
+     * returns false.
+     *
+     * @param info [OUT] A reference to a PricingInfo that will receive the pricing data.
+     * @return Returns true on success, or false if an error occurs (e.g., wrong event type).
      */
-    bool getConfigPaymentsEnabled(bool &paymentsEnabled) const
+    bool getPricingReceived(PricingInfo &info) const
     {
-        return ::sb_event_config_payments_enabled(m_event, &paymentsEnabled);
+        if (!::sb_event_pricing_free_play(m_event, &info.freePlay)) {
+            return false;
+        }
+        ::sb_event_pricing_payments_enabled(m_event, &info.paymentsEnabled);
+
+        const char *str = nullptr;
+        if (::sb_event_pricing_credit_price(m_event, &str) && str) {
+            info.creditPrice = str;
+        }
+        if (::sb_event_pricing_credit_regular_price(m_event, &str) && str) {
+            info.creditRegularPrice = str;
+        }
+        if (::sb_event_pricing_credit_sale_price(m_event, &str) && str) {
+            info.creditSalePrice = str;
+        }
+
+        int count = 0;
+        ::sb_event_pricing_bundles_count(m_event, &count);
+        info.bundles.clear();
+        for (int i = 0; i < count; ++i) {
+            BundlePrice bundle;
+            ::sb_event_pricing_bundle_credits(m_event, i, &bundle.credits);
+            if (::sb_event_pricing_bundle_price(m_event, i, &str) && str) {
+                bundle.price = str;
+            }
+            if (::sb_event_pricing_bundle_regular_price(m_event, i, &str) && str) {
+                bundle.regularPrice = str;
+            }
+            if (::sb_event_pricing_bundle_sale_price(m_event, i, &str) && str) {
+                bundle.salePrice = str;
+            }
+            info.bundles.push_back(std::move(bundle));
+        }
+        return true;
     }
 
     /**

--- a/include/scorbit_sdk/event_helpers_c.h
+++ b/include/scorbit_sdk/event_helpers_c.h
@@ -74,20 +74,6 @@ bool sb_event_credits_add_requested(const sb_event_t *event, int *credits,
                                     const char **transaction);
 
 /**
- * @brief Helper function to extract payments enabled status from a @ref SB_EVT_CONFIG_RECEIVED
- * event.
- *
- * This function extracts the payments_enabled field from a config received event.
- * The event type must be @ref SB_EVT_CONFIG_RECEIVED, otherwise the function returns an error.
- *
- * @param [IN] event A pointer to an sb_event_t structure containing the event data.
- * @param [OUT] payments_enabled A pointer to a bool that will receive the payments enabled value.
- * @return Returns true on success, or false if an error occurs (e.g., wrong event type was given).
- */
-SCORBIT_SDK_EXPORT
-bool sb_event_config_payments_enabled(const sb_event_t *event, bool *payments_enabled);
-
-/**
  * @brief Helper function to process a players updated event.
  *
  * Retrieves the total number of player slots in the event. Each slot corresponds to a player
@@ -221,6 +207,116 @@ bool sb_event_diagnostics_upload_requested(const sb_event_t *event, bool *includ
  */
 SCORBIT_SDK_EXPORT
 bool sb_event_diagnostics_uploaded(const sb_event_t *event, bool *success);
+
+// -------------------------------- Pricing helpers --------------------------------
+
+/**
+ * @brief Extract the free_play flag from a @ref SB_EVT_PRICING_RECEIVED event.
+ *
+ * @param [IN] event A pointer to an sb_event_t structure containing the event data.
+ * @param [OUT] free_play A pointer to a bool that will receive the free play value.
+ * @return Returns true on success, or false if the event type does not match.
+ */
+SCORBIT_SDK_EXPORT
+bool sb_event_pricing_free_play(const sb_event_t *event, bool *free_play);
+
+/**
+ * @brief Extract the payments_enabled flag from a @ref SB_EVT_PRICING_RECEIVED event.
+ *
+ * @param [IN] event A pointer to an sb_event_t structure containing the event data.
+ * @param [OUT] payments_enabled A pointer to a bool that will receive the payments enabled value.
+ * @return Returns true on success, or false if the event type does not match.
+ */
+SCORBIT_SDK_EXPORT
+bool sb_event_pricing_payments_enabled(const sb_event_t *event, bool *payments_enabled);
+
+/**
+ * @brief Get the effective price per credit as a decimal string (e.g. "0.75").
+ *
+ * Returns false when the event type does not match or the machine is in free play
+ * (prices are null).
+ *
+ * @param [IN] event A pointer to an sb_event_t structure containing the event data.
+ * @param [OUT] price A pointer to a string pointer that will receive the price.
+ * @return Returns true on success, or false if unavailable.
+ */
+SCORBIT_SDK_EXPORT
+bool sb_event_pricing_credit_price(const sb_event_t *event, const char **price);
+
+/**
+ * @brief Get the regular (non-discounted) price per credit as a decimal string.
+ *
+ * @param [IN] event A pointer to an sb_event_t structure containing the event data.
+ * @param [OUT] price A pointer to a string pointer that will receive the regular price.
+ * @return Returns true on success, or false if unavailable.
+ */
+SCORBIT_SDK_EXPORT
+bool sb_event_pricing_credit_regular_price(const sb_event_t *event, const char **price);
+
+/**
+ * @brief Get the sale price per credit as a decimal string, if a discount is active.
+ *
+ * @param [IN] event A pointer to an sb_event_t structure containing the event data.
+ * @param [OUT] price A pointer to a string pointer that will receive the sale price.
+ * @return Returns true on success, or false if there is no active sale or the event type
+ *         does not match.
+ */
+SCORBIT_SDK_EXPORT
+bool sb_event_pricing_credit_sale_price(const sb_event_t *event, const char **price);
+
+/**
+ * @brief Get the number of credit bundles available.
+ *
+ * @param [IN] event A pointer to an sb_event_t structure containing the event data.
+ * @param [OUT] count A pointer to an int that will receive the bundle count.
+ * @return Returns true on success, or false if the event type does not match.
+ */
+SCORBIT_SDK_EXPORT
+bool sb_event_pricing_bundles_count(const sb_event_t *event, int *count);
+
+/**
+ * @brief Get the number of credits in a bundle at the given index.
+ *
+ * @param [IN] event A pointer to an sb_event_t structure containing the event data.
+ * @param [IN] index The 0-based bundle index.
+ * @param [OUT] credits A pointer to an int that will receive the number of credits.
+ * @return Returns true on success, or false if the index is out of range.
+ */
+SCORBIT_SDK_EXPORT
+bool sb_event_pricing_bundle_credits(const sb_event_t *event, int index, int *credits);
+
+/**
+ * @brief Get the effective price for a bundle as a decimal string (e.g. "3.00").
+ *
+ * @param [IN] event A pointer to an sb_event_t structure containing the event data.
+ * @param [IN] index The 0-based bundle index.
+ * @param [OUT] price A pointer to a string pointer that will receive the price.
+ * @return Returns true on success, or false if the index is out of range.
+ */
+SCORBIT_SDK_EXPORT
+bool sb_event_pricing_bundle_price(const sb_event_t *event, int index, const char **price);
+
+/**
+ * @brief Get the regular (non-discounted) price for a bundle as a decimal string.
+ *
+ * @param [IN] event A pointer to an sb_event_t structure containing the event data.
+ * @param [IN] index The 0-based bundle index.
+ * @param [OUT] price A pointer to a string pointer that will receive the regular price.
+ * @return Returns true on success, or false if the index is out of range.
+ */
+SCORBIT_SDK_EXPORT
+bool sb_event_pricing_bundle_regular_price(const sb_event_t *event, int index, const char **price);
+
+/**
+ * @brief Get the sale price for a bundle as a decimal string, if a discount is active.
+ *
+ * @param [IN] event A pointer to an sb_event_t structure containing the event data.
+ * @param [IN] index The 0-based bundle index.
+ * @param [OUT] price A pointer to a string pointer that will receive the sale price.
+ * @return Returns true on success, or false if there is no active sale or index is out of range.
+ */
+SCORBIT_SDK_EXPORT
+bool sb_event_pricing_bundle_sale_price(const sb_event_t *event, int index, const char **price);
 
 // ------------------ OEM providers can ignore the event helpers below ------------------
 

--- a/include/scorbit_sdk/event_types.h
+++ b/include/scorbit_sdk/event_types.h
@@ -33,6 +33,7 @@ enum class EventType {
     PlayerPictureReady = SB_EVT_PLAYER_PICTURE_READY,
     DiagnosticsUploadRequested = SB_EVT_DIAGNOSTICS_UPLOAD_REQUESTED,
     DiagnosticsUploaded = SB_EVT_DIAGNOSTICS_UPLOADED,
+    PricingReceived = SB_EVT_PRICING_RECEIVED,
 
     // ---------------- OEM providers can ignore the events below ----------------
 

--- a/include/scorbit_sdk/event_types_c.h
+++ b/include/scorbit_sdk/event_types_c.h
@@ -52,7 +52,6 @@ typedef enum {
      * @brief A configuration has been received from the Scorbit system. This event is
      * typically sent after SDK connected to backend and received configuration.
      * Use @ref sb_event_config_received to get config JSON string.
-     * Use @ref sb_event_config_payments_enabled to check if payments are enabled in the config.
      */
     SB_EVT_CONFIG_RECEIVED,
 
@@ -79,6 +78,13 @@ typedef enum {
      * Use @ref sb_event_diagnostics_uploaded to check whether the upload succeeded.
      */
     SB_EVT_DIAGNOSTICS_UPLOADED,
+
+    /**
+     * @brief Pricing information has been received from the Scorbit system.
+     * Use @ref sb_event_pricing_free_play, @ref sb_event_pricing_payments_enabled,
+     * and credit/bundle accessors to retrieve pricing data.
+     */
+    SB_EVT_PRICING_RECEIVED,
 
     // ------------------ OEM providers can ignore the events below ------------------
 

--- a/include/scorbit_sdk/pricing_info.h
+++ b/include/scorbit_sdk/pricing_info.h
@@ -1,0 +1,43 @@
+/*
+ * Scorbit SDK
+ *
+ * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scrobit.io, All Rights Reserved
+ *
+ * MIT License
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#pragma once
+
+#include <string>
+#include <vector>
+
+namespace scorbit {
+
+struct BundlePrice {
+    int credits {0};
+    std::string price;        /// Effective price (sale or regular)
+    std::string regularPrice; /// Non-discounted price
+    std::string salePrice;    /// Discounted price, empty if no sale active
+};
+
+struct PricingInfo {
+    bool freePlay {false};
+    bool paymentsEnabled {false};
+    std::string creditPrice;        /// Effective price per credit (sale or regular)
+    std::string creditRegularPrice; /// Non-discounted price per credit
+    std::string creditSalePrice;    /// Discounted price per credit, empty if no sale active
+    std::vector<BundlePrice> bundles;
+};
+
+} // namespace scorbit

--- a/source/event_classes.h
+++ b/source/event_classes.h
@@ -149,16 +149,6 @@ public:
         return m_configJsonStr.c_str();
     }
 
-    auto paymentsEnabled() const -> std::optional<bool>
-    {
-        std::optional<bool> rv;
-        if (const auto it = m_configJson.find(JKEY_SOBJ_PAYMENTS_ENABLED);
-            it != m_configJson.end() && it->is_boolean()) {
-            rv = it->get<bool>();
-        }
-        return rv;
-    }
-
 private:
     nlohmann::json m_configJson;
     mutable std::string m_configJsonStr;
@@ -297,6 +287,85 @@ public:
 
 private:
     bool m_success;
+};
+
+// ---------------- PricingReceived implementation ----------------
+
+class PricingReceivedEvent : public EventBase
+{
+public:
+    struct Bundle {
+        int credits {0};
+        std::string price;
+        std::string regularPrice;
+        std::string salePrice;
+    };
+
+    explicit PricingReceivedEvent(const nlohmann::json &pricingJson)
+        : EventBase(EventType::PricingReceived, EventPriority::Normal)
+    {
+        m_freePlay = pricingJson.value("free_play", false);
+        m_paymentsEnabled = pricingJson.value("payments_enabled", false);
+
+        if (const auto pricesIt = pricingJson.find("prices");
+            pricesIt != pricingJson.end() && pricesIt->is_object()) {
+            const auto &prices = *pricesIt;
+
+            if (const auto creditIt = prices.find("credit");
+                creditIt != prices.end() && creditIt->is_object()) {
+                m_creditPrice = creditIt->value("price", "");
+                m_creditRegularPrice = creditIt->value("regular_price", "");
+                if (const auto sp = creditIt->find("sale_price");
+                    sp != creditIt->end() && sp->is_string()) {
+                    m_creditSalePrice = sp->get<std::string>();
+                }
+            }
+
+            if (const auto bundlesIt = prices.find("bundles");
+                bundlesIt != prices.end() && bundlesIt->is_array()) {
+                m_bundles.reserve(bundlesIt->size());
+                for (const auto &b : *bundlesIt) {
+                    if (!b.is_object()) {
+                        continue;
+                    }
+                    Bundle bundle;
+                    bundle.credits = b.value("credits", 0);
+                    bundle.price = b.value("price", "");
+                    bundle.regularPrice = b.value("regular_price", "");
+                    if (const auto sp = b.find("sale_price"); sp != b.end() && sp->is_string()) {
+                        bundle.salePrice = sp->get<std::string>();
+                    }
+                    m_bundles.push_back(std::move(bundle));
+                }
+            }
+        }
+    }
+
+    auto freePlay() const -> bool { return m_freePlay; }
+    auto paymentsEnabled() const -> bool { return m_paymentsEnabled; }
+
+    auto hasPrices() const -> bool { return !m_creditPrice.empty(); }
+
+    auto creditPrice() const -> const std::string & { return m_creditPrice; }
+    auto creditRegularPrice() const -> const std::string & { return m_creditRegularPrice; }
+    auto creditSalePrice() const -> const std::string & { return m_creditSalePrice; }
+
+    auto bundlesCount() const -> int { return static_cast<int>(m_bundles.size()); }
+    auto bundle(int index) const -> const Bundle *
+    {
+        if (index < 0 || index >= static_cast<int>(m_bundles.size())) {
+            return nullptr;
+        }
+        return &m_bundles[index];
+    }
+
+private:
+    bool m_freePlay {false};
+    bool m_paymentsEnabled {false};
+    std::string m_creditPrice;
+    std::string m_creditRegularPrice;
+    std::string m_creditSalePrice;
+    std::vector<Bundle> m_bundles;
 };
 
 } // namespace detail

--- a/source/event_helpers_c.cpp
+++ b/source/event_helpers_c.cpp
@@ -62,25 +62,6 @@ bool sb_event_credits_add_requested(const sb_event_t *event, int *credits, const
     return true;
 }
 
-bool sb_event_config_payments_enabled(const sb_event_t *event, bool *payments_enabled)
-{
-    if (!event || !payments_enabled) {
-        return false;
-    }
-
-    auto derived = dynamic_cast<const scorbit::detail::ConfigReceivedEvent *>(event);
-    if (!derived) {
-        return false;
-    }
-
-    if (const auto rv = derived->paymentsEnabled(); rv) {
-        *payments_enabled = *rv;
-        return true;
-    }
-
-    return false;
-}
-
 bool sb_event_diagnostics_upload_requested(const sb_event_t *event, bool *include_recordings)
 {
     if (!event || !include_recordings) {
@@ -307,5 +288,169 @@ bool sb_event_player_picture_ready(const sb_event_t *event, sb_player_t *player,
     *player = derived->player();
     *data = derived->pictureData();
     *size = derived->pictureSize();
+    return true;
+}
+
+// ----------------------- Pricing helpers -----------------------
+
+static const scorbit::detail::PricingReceivedEvent *toPricingEvent(const sb_event_t *event)
+{
+    if (!event) {
+        return nullptr;
+    }
+    return dynamic_cast<const scorbit::detail::PricingReceivedEvent *>(event);
+}
+
+bool sb_event_pricing_free_play(const sb_event_t *event, bool *free_play)
+{
+    if (!free_play) {
+        return false;
+    }
+    auto derived = toPricingEvent(event);
+    if (!derived) {
+        return false;
+    }
+    *free_play = derived->freePlay();
+    return true;
+}
+
+bool sb_event_pricing_payments_enabled(const sb_event_t *event, bool *payments_enabled)
+{
+    if (!payments_enabled) {
+        return false;
+    }
+    auto derived = toPricingEvent(event);
+    if (!derived) {
+        return false;
+    }
+    *payments_enabled = derived->paymentsEnabled();
+    return true;
+}
+
+bool sb_event_pricing_credit_price(const sb_event_t *event, const char **price)
+{
+    if (!price) {
+        return false;
+    }
+    auto derived = toPricingEvent(event);
+    if (!derived || !derived->hasPrices()) {
+        return false;
+    }
+    *price = derived->creditPrice().c_str();
+    return true;
+}
+
+bool sb_event_pricing_credit_regular_price(const sb_event_t *event, const char **price)
+{
+    if (!price) {
+        return false;
+    }
+    auto derived = toPricingEvent(event);
+    if (!derived || !derived->hasPrices()) {
+        return false;
+    }
+    *price = derived->creditRegularPrice().c_str();
+    return true;
+}
+
+bool sb_event_pricing_credit_sale_price(const sb_event_t *event, const char **price)
+{
+    if (!price) {
+        return false;
+    }
+    auto derived = toPricingEvent(event);
+    if (!derived || !derived->hasPrices()) {
+        return false;
+    }
+    const auto &salePrice = derived->creditSalePrice();
+    if (salePrice.empty()) {
+        return false;
+    }
+    *price = salePrice.c_str();
+    return true;
+}
+
+bool sb_event_pricing_bundles_count(const sb_event_t *event, int *count)
+{
+    if (!count) {
+        return false;
+    }
+    auto derived = toPricingEvent(event);
+    if (!derived) {
+        return false;
+    }
+    *count = derived->bundlesCount();
+    return true;
+}
+
+bool sb_event_pricing_bundle_credits(const sb_event_t *event, int index, int *credits)
+{
+    if (!credits) {
+        return false;
+    }
+    auto derived = toPricingEvent(event);
+    if (!derived) {
+        return false;
+    }
+    auto b = derived->bundle(index);
+    if (!b) {
+        return false;
+    }
+    *credits = b->credits;
+    return true;
+}
+
+bool sb_event_pricing_bundle_price(const sb_event_t *event, int index, const char **price)
+{
+    if (!price) {
+        return false;
+    }
+    auto derived = toPricingEvent(event);
+    if (!derived) {
+        return false;
+    }
+    auto b = derived->bundle(index);
+    if (!b) {
+        return false;
+    }
+    *price = b->price.c_str();
+    return true;
+}
+
+bool sb_event_pricing_bundle_regular_price(const sb_event_t *event, int index, const char **price)
+{
+    if (!price) {
+        return false;
+    }
+    auto derived = toPricingEvent(event);
+    if (!derived) {
+        return false;
+    }
+    auto b = derived->bundle(index);
+    if (!b) {
+        return false;
+    }
+    *price = b->regularPrice.c_str();
+    return true;
+}
+
+bool sb_event_pricing_bundle_sale_price(const sb_event_t *event, int index, const char **price)
+{
+    if (!price) {
+        return false;
+    }
+    auto derived = toPricingEvent(event);
+    if (!derived) {
+        return false;
+    }
+    auto b = derived->bundle(index);
+    if (!b) {
+        return false;
+    }
+    const auto &salePrice = b->salePrice;
+    if (salePrice.empty()) {
+        return false;
+    }
+    *price = salePrice.c_str();
     return true;
 }

--- a/source/identifiers.h
+++ b/source/identifiers.h
@@ -36,7 +36,8 @@ constexpr auto URL_SCORBITRON_DIAGNOSTICS {"v2/scorbitrons/{scorbitron_uuid}/dia
 constexpr auto URL_V2_PROVISION {"v2/provision/"};
 
 constexpr auto URL_NFC_TAG {"https://scorbit.link/machines/{machine_uuid}?n={nonce}"};
-constexpr auto URL_CLAIM_DEEPLINK {"https://scorbit.link/machines/{machine_uuid}/?score_id={score_id}"};
+constexpr auto URL_CLAIM_DEEPLINK {
+        "https://scorbit.link/machines/{machine_uuid}/?score_id={score_id}"};
 
 constexpr auto URL_SESSIONS_ID {"sessions"};
 
@@ -143,6 +144,7 @@ constexpr auto JKEY_SCFG_CONFIG {"config"};
 constexpr auto JKEY_SCFG_OPDB_ID {"opdb_id"};
 constexpr auto JKEY_SCFG_SCORBITRON_MACHINE {"machine"};
 constexpr auto JKEY_SCFG_OWNER {"owner"};
+constexpr auto JKEY_SCFG_PRICING {"pricing"};
 
 constexpr auto JKEY_SCFG_VERSION {"version"};
 constexpr auto JKEY_SCFG_TYPE {"type"};
@@ -162,7 +164,6 @@ constexpr auto JKEY_SOBJ_CREDIT_DROP_CAPABLE {"credit_drop_capable"};
 
 constexpr auto JKEY_SOBJ_RELEASE_TRACK {"release_track"};
 constexpr auto JKEY_SOBJ_RELEASE_URL {"url"};
-constexpr auto JKEY_SOBJ_PAYMENTS_ENABLED {"payments_enabled"};
 
 // Machine object
 constexpr auto JKEY_MOBJ_NAME {"name"};
@@ -205,6 +206,7 @@ constexpr auto JKEY_URL {"url"};
 constexpr auto JKEY_ACTION_NAME {"name"};
 constexpr auto JVAL_ACITON_GET_SCORBITRON_SESSION {"scorbitronSessionRetreive"};
 constexpr auto JVAL_ACTION_UPLOAD_DIAGNOSTICS {"scorbitronUploadDiagnostics"};
+constexpr auto JVAL_ACTION_CONFIG_REFRESH {"scorbitronConfigRefresh"};
 
 constexpr auto JVAL_NONCES {"nonces"};
 

--- a/source/net.cpp
+++ b/source/net.cpp
@@ -455,6 +455,11 @@ void Net::getConfig()
 
                     m_eventManager->push(std::make_shared<ConfigReceivedEvent>(json));
 
+                    if (const auto pricingIt = json.find(JKEY_SCFG_PRICING);
+                        pricingIt != json.end() && pricingIt->is_object()) {
+                        m_eventManager->push(std::make_shared<PricingReceivedEvent>(*pricingIt));
+                    }
+
                 } catch (const std::exception &e) {
                     ERR("API error parsing config reply: {}", e.what());
                 }
@@ -2420,6 +2425,10 @@ void Net::centrifugoSetup()
                             INF("API-CF Diagnostics upload requested via control channel");
                             m_eventManager->push(
                                     std::make_shared<DiagnosticsUploadRequestedEvent>(false));
+                        } else if (method == JVAL_METHOD_GET
+                                   && name == JVAL_ACTION_CONFIG_REFRESH) {
+                            INF("API-CF Config refresh requested via control channel");
+                            getConfig();
                         }
                     }
                 }

--- a/tests/test_detail/CMakeLists.txt
+++ b/tests/test_detail/CMakeLists.txt
@@ -140,6 +140,7 @@ target_sources(
         ../../source/event_classes.h
         source/test_event_queue.cpp
         ../../source/event_manager.h
+        ../../source/event_helpers_c.cpp
         source/test_event_manager.cpp
         ../../source/updater.h
         ../../source/updater.cpp

--- a/tests/test_detail/source/test_event_manager.cpp
+++ b/tests/test_detail/source/test_event_manager.cpp
@@ -21,6 +21,7 @@
 #include <event_queue.h>
 #include <event_classes.h>
 #include <scorbit_sdk/event_types.h>
+#include <scorbit_sdk/event_helpers_c.h>
 
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_vector.hpp>
@@ -66,6 +67,41 @@ std::shared_ptr<EventBase> createDiagnosticsUploadRequestedEvent(bool includeRec
 std::shared_ptr<EventBase> createDiagnosticsUploadedEvent(bool success = true)
 {
     return std::make_shared<DiagnosticsUploadedEvent>(success);
+}
+
+nlohmann::json fullPricingJson()
+{
+    return {
+        {"free_play", false},
+        {"payments_enabled", true},
+        {"prices", {
+            {"credit", {
+                {"price", "0.75"},
+                {"regular_price", "0.75"},
+                {"sale_price", nullptr}
+            }},
+            {"bundles", {
+                {{"credits", 5}, {"price", "3.00"}, {"regular_price", "3.00"}, {"sale_price", nullptr}},
+                {{"credits", 10}, {"price", "5.75"}, {"regular_price", "5.75"}, {"sale_price", "5.00"}}
+            }}
+        }},
+        {"simulate_free_play", false}
+    };
+}
+
+nlohmann::json freePlayPricingJson()
+{
+    return {
+        {"free_play", true},
+        {"payments_enabled", false},
+        {"prices", nullptr},
+        {"simulate_free_play", false}
+    };
+}
+
+std::shared_ptr<EventBase> createPricingEvent(const nlohmann::json &pricing)
+{
+    return std::make_shared<PricingReceivedEvent>(pricing);
 }
 
 } // namespace
@@ -608,5 +644,198 @@ TEST_CASE("EventManager processing state")
         ioThread.join();
 
         CHECK(callbackCount.load() == 10);
+    }
+}
+
+TEST_CASE("PricingReceivedEvent full pricing")
+{
+    boost::asio::io_context ioContext;
+    auto strand = boost::asio::make_strand(ioContext);
+
+    const PricingReceivedEvent *captured = nullptr;
+    auto callback = [&captured](const EventBase &event) {
+        if (event.type() == EventType::PricingReceived) {
+            captured = static_cast<const PricingReceivedEvent *>(&event);
+        }
+    };
+
+    auto eventManager = std::make_shared<EventManager>(strand, callback);
+
+    SECTION("Full pricing data extraction")
+    {
+        eventManager->push(createPricingEvent(fullPricingJson()));
+        ioContext.run_for(std::chrono::milliseconds(50));
+
+        REQUIRE(captured != nullptr);
+        CHECK(captured->freePlay() == false);
+        CHECK(captured->paymentsEnabled() == true);
+        CHECK(captured->hasPrices() == true);
+        CHECK(captured->creditPrice() == "0.75");
+        CHECK(captured->creditRegularPrice() == "0.75");
+        CHECK(captured->creditSalePrice().empty());
+        CHECK(captured->bundlesCount() == 2);
+
+        auto b0 = captured->bundle(0);
+        REQUIRE(b0 != nullptr);
+        CHECK(b0->credits == 5);
+        CHECK(b0->price == "3.00");
+        CHECK(b0->regularPrice == "3.00");
+        CHECK(b0->salePrice.empty());
+
+        auto b1 = captured->bundle(1);
+        REQUIRE(b1 != nullptr);
+        CHECK(b1->credits == 10);
+        CHECK(b1->price == "5.75");
+        CHECK(b1->regularPrice == "5.75");
+        CHECK(b1->salePrice == "5.00");
+
+        CHECK(captured->bundle(-1) == nullptr);
+        CHECK(captured->bundle(2) == nullptr);
+    }
+}
+
+TEST_CASE("PricingReceivedEvent free play")
+{
+    boost::asio::io_context ioContext;
+    auto strand = boost::asio::make_strand(ioContext);
+
+    const PricingReceivedEvent *captured = nullptr;
+    auto callback = [&captured](const EventBase &event) {
+        if (event.type() == EventType::PricingReceived) {
+            captured = static_cast<const PricingReceivedEvent *>(&event);
+        }
+    };
+
+    auto eventManager = std::make_shared<EventManager>(strand, callback);
+
+    SECTION("Free play: no prices")
+    {
+        eventManager->push(createPricingEvent(freePlayPricingJson()));
+        ioContext.run_for(std::chrono::milliseconds(50));
+
+        REQUIRE(captured != nullptr);
+        CHECK(captured->freePlay() == true);
+        CHECK(captured->paymentsEnabled() == false);
+        CHECK(captured->hasPrices() == false);
+        CHECK(captured->creditPrice().empty());
+        CHECK(captured->bundlesCount() == 0);
+    }
+}
+
+TEST_CASE("PricingReceivedEvent C helpers")
+{
+    auto pricing = fullPricingJson();
+    PricingReceivedEvent event(pricing);
+    const sb_event_t *ev = &event;
+
+    SECTION("Boolean flags")
+    {
+        bool free_play = true;
+        CHECK(sb_event_pricing_free_play(ev, &free_play));
+        CHECK(free_play == false);
+
+        bool payments = false;
+        CHECK(sb_event_pricing_payments_enabled(ev, &payments));
+        CHECK(payments == true);
+    }
+
+    SECTION("Credit prices")
+    {
+        const char *price = nullptr;
+        CHECK(sb_event_pricing_credit_price(ev, &price));
+        CHECK(std::string(price) == "0.75");
+
+        CHECK(sb_event_pricing_credit_regular_price(ev, &price));
+        CHECK(std::string(price) == "0.75");
+
+        CHECK_FALSE(sb_event_pricing_credit_sale_price(ev, &price));
+    }
+
+    SECTION("Bundles")
+    {
+        int count = 0;
+        CHECK(sb_event_pricing_bundles_count(ev, &count));
+        CHECK(count == 2);
+
+        int credits = 0;
+        CHECK(sb_event_pricing_bundle_credits(ev, 0, &credits));
+        CHECK(credits == 5);
+
+        const char *price = nullptr;
+        CHECK(sb_event_pricing_bundle_price(ev, 0, &price));
+        CHECK(std::string(price) == "3.00");
+
+        CHECK(sb_event_pricing_bundle_credits(ev, 1, &credits));
+        CHECK(credits == 10);
+
+        CHECK(sb_event_pricing_bundle_sale_price(ev, 1, &price));
+        CHECK(std::string(price) == "5.00");
+
+        CHECK_FALSE(sb_event_pricing_bundle_credits(ev, 2, &credits));
+    }
+
+    SECTION("Wrong event type returns false")
+    {
+        GameStartRequestedEvent wrongEvent(2);
+        const sb_event_t *wrong = &wrongEvent;
+
+        bool free_play = false;
+        CHECK_FALSE(sb_event_pricing_free_play(wrong, &free_play));
+
+        const char *price = nullptr;
+        CHECK_FALSE(sb_event_pricing_credit_price(wrong, &price));
+    }
+
+    SECTION("Null pointers return false")
+    {
+        CHECK_FALSE(sb_event_pricing_free_play(nullptr, nullptr));
+        CHECK_FALSE(sb_event_pricing_free_play(ev, nullptr));
+        CHECK_FALSE(sb_event_pricing_credit_price(ev, nullptr));
+        CHECK_FALSE(sb_event_pricing_bundles_count(ev, nullptr));
+    }
+}
+
+TEST_CASE("PricingReceivedEvent free play C helpers")
+{
+    auto pricing = freePlayPricingJson();
+    PricingReceivedEvent event(pricing);
+    const sb_event_t *ev = &event;
+
+    bool free_play = false;
+    CHECK(sb_event_pricing_free_play(ev, &free_play));
+    CHECK(free_play == true);
+
+    const char *price = nullptr;
+    CHECK_FALSE(sb_event_pricing_credit_price(ev, &price));
+
+    int count = 0;
+    CHECK(sb_event_pricing_bundles_count(ev, &count));
+    CHECK(count == 0);
+}
+
+TEST_CASE("PricingReceivedEvent ordering")
+{
+    boost::asio::io_context ioContext;
+    auto strand = boost::asio::make_strand(ioContext);
+
+    std::vector<EventType> receivedEvents;
+    auto callback = [&receivedEvents](const EventBase &event) {
+        receivedEvents.push_back(event.type());
+    };
+
+    auto eventManager = std::make_shared<EventManager>(strand, callback);
+
+    SECTION("Pricing events among other events")
+    {
+        eventManager->push(createPricingEvent(fullPricingJson()));
+        eventManager->push(createGameStartEvent(2));
+        eventManager->push(createConfigEvent({{"id", "test"}}));
+
+        ioContext.run_for(std::chrono::milliseconds(50));
+
+        REQUIRE(receivedEvents.size() == 3);
+        CHECK(receivedEvents[0] == EventType::GameStartRequested);
+        CHECK(receivedEvents[1] == EventType::PricingReceived);
+        CHECK(receivedEvents[2] == EventType::ConfigReceived);
     }
 }

--- a/wrappers/python/README.md
+++ b/wrappers/python/README.md
@@ -159,7 +159,7 @@ From `scorbit.create_game_state(config)`. Supports `with` / `__exit__` cleanup.
 |--------|---------|
 | `get_game_start_requested()` | `int` (player count) or `None` |
 | `get_credits_add_requested()` | `(int, str)` or `None` |
-| `get_config_payments_enabled()` | `bool` or `None` |
+| `get_pricing_received()` | `PricingInfo` or `None` |
 | `get_config_received()` | JSON `str` or `None` |
 | `get_players_updated()` | `dict[int, PlayerInfo]` or `None` |
 | `get_player_picture_ready()` | `(int, bytes)` or `None` |

--- a/wrappers/python/src/scorbit/__init__.py
+++ b/wrappers/python/src/scorbit/__init__.py
@@ -48,7 +48,7 @@ from ._enums import (
     GameStartOrigin,
     LogLevel,
 )
-from ._types import PlayerInfo
+from ._types import BundlePrice, PlayerInfo, PricingInfo
 from .config import Config
 from .event import Event
 from .game_state import GameState, create_game_state
@@ -115,7 +115,9 @@ __all__ = [
     "GameStartOrigin",
     "LogLevel",
     # Types
+    "BundlePrice",
     "PlayerInfo",
+    "PricingInfo",
     # Classes
     "Config",
     "Event",

--- a/wrappers/python/src/scorbit/_bindings.py
+++ b/wrappers/python/src/scorbit/_bindings.py
@@ -313,10 +313,6 @@ _lib.sb_event_game_start_requested.argtypes = [c_void_p, POINTER(c_int)]
 _lib.sb_event_credits_add_requested.restype = c_bool
 _lib.sb_event_credits_add_requested.argtypes = [c_void_p, POINTER(c_int), POINTER(c_char_p)]
 
-# bool sb_event_config_payments_enabled(const sb_event_t*, bool*)
-_lib.sb_event_config_payments_enabled.restype = c_bool
-_lib.sb_event_config_payments_enabled.argtypes = [c_void_p, POINTER(c_bool)]
-
 # bool sb_event_players_updated(const sb_event_t*, int*)
 _lib.sb_event_players_updated.restype = c_bool
 _lib.sb_event_players_updated.argtypes = [c_void_p, POINTER(c_int)]
@@ -378,6 +374,48 @@ _lib.sb_event_diagnostics_upload_requested.argtypes = [c_void_p, POINTER(c_bool)
 # bool sb_event_diagnostics_uploaded(const sb_event_t*, bool*)
 _lib.sb_event_diagnostics_uploaded.restype = c_bool
 _lib.sb_event_diagnostics_uploaded.argtypes = [c_void_p, POINTER(c_bool)]
+
+# -- Pricing event helpers --
+
+# bool sb_event_pricing_free_play(const sb_event_t*, bool*)
+_lib.sb_event_pricing_free_play.restype = c_bool
+_lib.sb_event_pricing_free_play.argtypes = [c_void_p, POINTER(c_bool)]
+
+# bool sb_event_pricing_payments_enabled(const sb_event_t*, bool*)
+_lib.sb_event_pricing_payments_enabled.restype = c_bool
+_lib.sb_event_pricing_payments_enabled.argtypes = [c_void_p, POINTER(c_bool)]
+
+# bool sb_event_pricing_credit_price(const sb_event_t*, const char**)
+_lib.sb_event_pricing_credit_price.restype = c_bool
+_lib.sb_event_pricing_credit_price.argtypes = [c_void_p, POINTER(c_char_p)]
+
+# bool sb_event_pricing_credit_regular_price(const sb_event_t*, const char**)
+_lib.sb_event_pricing_credit_regular_price.restype = c_bool
+_lib.sb_event_pricing_credit_regular_price.argtypes = [c_void_p, POINTER(c_char_p)]
+
+# bool sb_event_pricing_credit_sale_price(const sb_event_t*, const char**)
+_lib.sb_event_pricing_credit_sale_price.restype = c_bool
+_lib.sb_event_pricing_credit_sale_price.argtypes = [c_void_p, POINTER(c_char_p)]
+
+# bool sb_event_pricing_bundles_count(const sb_event_t*, int*)
+_lib.sb_event_pricing_bundles_count.restype = c_bool
+_lib.sb_event_pricing_bundles_count.argtypes = [c_void_p, POINTER(c_int)]
+
+# bool sb_event_pricing_bundle_credits(const sb_event_t*, int, int*)
+_lib.sb_event_pricing_bundle_credits.restype = c_bool
+_lib.sb_event_pricing_bundle_credits.argtypes = [c_void_p, c_int, POINTER(c_int)]
+
+# bool sb_event_pricing_bundle_price(const sb_event_t*, int, const char**)
+_lib.sb_event_pricing_bundle_price.restype = c_bool
+_lib.sb_event_pricing_bundle_price.argtypes = [c_void_p, c_int, POINTER(c_char_p)]
+
+# bool sb_event_pricing_bundle_regular_price(const sb_event_t*, int, const char**)
+_lib.sb_event_pricing_bundle_regular_price.restype = c_bool
+_lib.sb_event_pricing_bundle_regular_price.argtypes = [c_void_p, c_int, POINTER(c_char_p)]
+
+# bool sb_event_pricing_bundle_sale_price(const sb_event_t*, int, const char**)
+_lib.sb_event_pricing_bundle_sale_price.restype = c_bool
+_lib.sb_event_pricing_bundle_sale_price.argtypes = [c_void_p, c_int, POINTER(c_char_p)]
 
 # void sb_upload_diagnostics(sb_game_handle_t, const char**, size_t,
 #                             const char**, size_t, const char*)

--- a/wrappers/python/src/scorbit/_enums.py
+++ b/wrappers/python/src/scorbit/_enums.py
@@ -65,6 +65,7 @@ class EventType(IntEnum):
     PlayerPictureReady = 5
     DiagnosticsUploadRequested = 6
     DiagnosticsUploaded = 7
+    PricingReceived = 8
 
     # Internal / scorbitd events
     _None = 1000

--- a/wrappers/python/src/scorbit/_types.py
+++ b/wrappers/python/src/scorbit/_types.py
@@ -10,6 +10,77 @@
 """Shared data types used across the wrapper."""
 
 
+class BundlePrice(object):
+    """A credit bundle with pricing.
+
+    Attributes:
+        credits: Number of credits in this bundle.
+        price: Effective price (sale or regular) as a decimal string.
+        regular_price: Non-discounted price as a decimal string.
+        sale_price: Discounted price as a decimal string, empty if no sale.
+    """
+
+    __slots__ = ("credits", "price", "regular_price", "sale_price")
+
+    def __init__(self, credits=0, price="", regular_price="", sale_price=""):
+        # type: (int, str, str, str) -> None
+        self.credits = credits
+        self.price = price
+        self.regular_price = regular_price
+        self.sale_price = sale_price
+
+    def __repr__(self):
+        # type: () -> str
+        return "BundlePrice(credits={!r}, price={!r})".format(
+            self.credits, self.price
+        )
+
+
+class PricingInfo(object):
+    """Pricing configuration for the machine.
+
+    Attributes:
+        free_play: Whether the machine is in free play mode.
+        payments_enabled: Whether payments are enabled.
+        credit_price: Effective price per credit as a decimal string.
+        credit_regular_price: Non-discounted price per credit.
+        credit_sale_price: Sale price per credit, empty if no sale.
+        bundles: List of :class:`BundlePrice` objects.
+    """
+
+    __slots__ = (
+        "free_play",
+        "payments_enabled",
+        "credit_price",
+        "credit_regular_price",
+        "credit_sale_price",
+        "bundles",
+    )
+
+    def __init__(
+        self,
+        free_play=False,
+        payments_enabled=False,
+        credit_price="",
+        credit_regular_price="",
+        credit_sale_price="",
+        bundles=None,
+    ):
+        # type: (bool, bool, str, str, str, list) -> None
+        self.free_play = free_play
+        self.payments_enabled = payments_enabled
+        self.credit_price = credit_price
+        self.credit_regular_price = credit_regular_price
+        self.credit_sale_price = credit_sale_price
+        self.bundles = bundles if bundles is not None else []
+
+    def __repr__(self):
+        # type: () -> str
+        return "PricingInfo(free_play={!r}, payments_enabled={!r}, credit_price={!r}, bundles={!r})".format(
+            self.free_play, self.payments_enabled, self.credit_price, len(self.bundles)
+        )
+
+
 class PlayerInfo(object):
     """Player profile information.
 

--- a/wrappers/python/src/scorbit/event.py
+++ b/wrappers/python/src/scorbit/event.py
@@ -17,7 +17,7 @@ from ctypes import POINTER, byref, c_bool, c_char_p, c_int, c_size_t, c_uint, c_
 
 from ._bindings import _lib
 from ._enums import EventType
-from ._types import PlayerInfo
+from ._types import BundlePrice, PlayerInfo, PricingInfo
 
 
 class Event(object):
@@ -84,20 +84,73 @@ class Event(object):
         return None
 
     # ------------------------------------------------------------------
-    # Config
+    # Pricing
     # ------------------------------------------------------------------
 
-    def get_config_payments_enabled(self):
-        # type: () -> bool | None
-        """Extract the ``payments_enabled`` flag from a ``ConfigReceived`` event.
+    def _get_pricing_str(self, func):
+        # type: (...) -> str
+        out = c_char_p()
+        if func(self._ptr, byref(out)):
+            val = out.value
+            if isinstance(val, bytes):
+                val = val.decode("utf-8", errors="replace")
+            return val or ""
+        return ""
+
+    def _get_bundle_str(self, func, index):
+        # type: (...) -> str
+        out = c_char_p()
+        if func(self._ptr, c_int(index), byref(out)):
+            val = out.value
+            if isinstance(val, bytes):
+                val = val.decode("utf-8", errors="replace")
+            return val or ""
+        return ""
+
+    def get_pricing_received(self):
+        # type: () -> PricingInfo | None
+        """Parse a ``PricingReceived`` event.
 
         Returns:
-            ``True`` / ``False``, or ``None`` if the event type does not match.
+            A :class:`PricingInfo` object, or ``None`` if the event type
+            does not match.
         """
-        enabled = c_bool(False)
-        if _lib.sb_event_config_payments_enabled(self._ptr, byref(enabled)):
-            return bool(enabled.value)
-        return None
+        free_play = c_bool(False)
+        if not _lib.sb_event_pricing_free_play(self._ptr, byref(free_play)):
+            return None
+
+        payments_enabled = c_bool(False)
+        _lib.sb_event_pricing_payments_enabled(self._ptr, byref(payments_enabled))
+
+        credit_price = self._get_pricing_str(_lib.sb_event_pricing_credit_price)
+        credit_regular = self._get_pricing_str(_lib.sb_event_pricing_credit_regular_price)
+        credit_sale = self._get_pricing_str(_lib.sb_event_pricing_credit_sale_price)
+
+        count = c_int(0)
+        _lib.sb_event_pricing_bundles_count(self._ptr, byref(count))
+        bundles = []
+        for i in range(count.value):
+            credits = c_int(0)
+            _lib.sb_event_pricing_bundle_credits(self._ptr, c_int(i), byref(credits))
+            bundles.append(BundlePrice(
+                credits=credits.value,
+                price=self._get_bundle_str(_lib.sb_event_pricing_bundle_price, i),
+                regular_price=self._get_bundle_str(_lib.sb_event_pricing_bundle_regular_price, i),
+                sale_price=self._get_bundle_str(_lib.sb_event_pricing_bundle_sale_price, i),
+            ))
+
+        return PricingInfo(
+            free_play=bool(free_play.value),
+            payments_enabled=bool(payments_enabled.value),
+            credit_price=credit_price,
+            credit_regular_price=credit_regular,
+            credit_sale_price=credit_sale,
+            bundles=bundles,
+        )
+
+    # ------------------------------------------------------------------
+    # Config
+    # ------------------------------------------------------------------
 
     def get_config_received(self):
         # type: () -> str | None

--- a/wrappers/python27/README.md
+++ b/wrappers/python27/README.md
@@ -171,7 +171,7 @@ Helpers return parsed data or `None` if the type does not match.
 | `type` | `EventType` |
 | `get_game_start_requested()` | `int` or `None` |
 | `get_credits_add_requested()` | `(int, str)` or `None` |
-| `get_config_payments_enabled()` | `bool` or `None` |
+| `get_pricing_received()` | `PricingInfo` or `None` |
 | `get_config_received()` | JSON `str` or `None` |
 | `get_players_updated()` | `dict` (player number → `PlayerInfo`) or `None` |
 | `get_player_picture_ready()` | `(int, bytes)` or `None` |

--- a/wrappers/python27/src/scorbit/__init__.py
+++ b/wrappers/python27/src/scorbit/__init__.py
@@ -48,7 +48,7 @@ from ._enums import (
     GameStartOrigin,
     LogLevel,
 )
-from ._types import PlayerInfo
+from ._types import BundlePrice, PlayerInfo, PricingInfo
 from .config import Config
 from .event import Event
 from .game_state import GameState, create_game_state
@@ -114,7 +114,9 @@ __all__ = [
     "GameStartOrigin",
     "LogLevel",
     # Types
+    "BundlePrice",
     "PlayerInfo",
+    "PricingInfo",
     # Classes
     "Config",
     "Event",

--- a/wrappers/python27/src/scorbit/_bindings.py
+++ b/wrappers/python27/src/scorbit/_bindings.py
@@ -315,10 +315,6 @@ _lib.sb_event_game_start_requested.argtypes = [c_void_p, POINTER(c_int)]
 _lib.sb_event_credits_add_requested.restype = c_bool
 _lib.sb_event_credits_add_requested.argtypes = [c_void_p, POINTER(c_int), POINTER(c_char_p)]
 
-# bool sb_event_config_payments_enabled(const sb_event_t*, bool*)
-_lib.sb_event_config_payments_enabled.restype = c_bool
-_lib.sb_event_config_payments_enabled.argtypes = [c_void_p, POINTER(c_bool)]
-
 # bool sb_event_players_updated(const sb_event_t*, int*)
 _lib.sb_event_players_updated.restype = c_bool
 _lib.sb_event_players_updated.argtypes = [c_void_p, POINTER(c_int)]
@@ -380,6 +376,48 @@ _lib.sb_event_diagnostics_upload_requested.argtypes = [c_void_p, POINTER(c_bool)
 # bool sb_event_diagnostics_uploaded(const sb_event_t*, bool*)
 _lib.sb_event_diagnostics_uploaded.restype = c_bool
 _lib.sb_event_diagnostics_uploaded.argtypes = [c_void_p, POINTER(c_bool)]
+
+# -- Pricing event helpers --
+
+# bool sb_event_pricing_free_play(const sb_event_t*, bool*)
+_lib.sb_event_pricing_free_play.restype = c_bool
+_lib.sb_event_pricing_free_play.argtypes = [c_void_p, POINTER(c_bool)]
+
+# bool sb_event_pricing_payments_enabled(const sb_event_t*, bool*)
+_lib.sb_event_pricing_payments_enabled.restype = c_bool
+_lib.sb_event_pricing_payments_enabled.argtypes = [c_void_p, POINTER(c_bool)]
+
+# bool sb_event_pricing_credit_price(const sb_event_t*, const char**)
+_lib.sb_event_pricing_credit_price.restype = c_bool
+_lib.sb_event_pricing_credit_price.argtypes = [c_void_p, POINTER(c_char_p)]
+
+# bool sb_event_pricing_credit_regular_price(const sb_event_t*, const char**)
+_lib.sb_event_pricing_credit_regular_price.restype = c_bool
+_lib.sb_event_pricing_credit_regular_price.argtypes = [c_void_p, POINTER(c_char_p)]
+
+# bool sb_event_pricing_credit_sale_price(const sb_event_t*, const char**)
+_lib.sb_event_pricing_credit_sale_price.restype = c_bool
+_lib.sb_event_pricing_credit_sale_price.argtypes = [c_void_p, POINTER(c_char_p)]
+
+# bool sb_event_pricing_bundles_count(const sb_event_t*, int*)
+_lib.sb_event_pricing_bundles_count.restype = c_bool
+_lib.sb_event_pricing_bundles_count.argtypes = [c_void_p, POINTER(c_int)]
+
+# bool sb_event_pricing_bundle_credits(const sb_event_t*, int, int*)
+_lib.sb_event_pricing_bundle_credits.restype = c_bool
+_lib.sb_event_pricing_bundle_credits.argtypes = [c_void_p, c_int, POINTER(c_int)]
+
+# bool sb_event_pricing_bundle_price(const sb_event_t*, int, const char**)
+_lib.sb_event_pricing_bundle_price.restype = c_bool
+_lib.sb_event_pricing_bundle_price.argtypes = [c_void_p, c_int, POINTER(c_char_p)]
+
+# bool sb_event_pricing_bundle_regular_price(const sb_event_t*, int, const char**)
+_lib.sb_event_pricing_bundle_regular_price.restype = c_bool
+_lib.sb_event_pricing_bundle_regular_price.argtypes = [c_void_p, c_int, POINTER(c_char_p)]
+
+# bool sb_event_pricing_bundle_sale_price(const sb_event_t*, int, const char**)
+_lib.sb_event_pricing_bundle_sale_price.restype = c_bool
+_lib.sb_event_pricing_bundle_sale_price.argtypes = [c_void_p, c_int, POINTER(c_char_p)]
 
 # void sb_upload_diagnostics(sb_game_handle_t, const char**, size_t,
 #                             const char**, size_t, const char*)

--- a/wrappers/python27/src/scorbit/_enums.py
+++ b/wrappers/python27/src/scorbit/_enums.py
@@ -71,6 +71,7 @@ class EventType(IntEnum):
     PlayerPictureReady = 5
     DiagnosticsUploadRequested = 6
     DiagnosticsUploaded = 7
+    PricingReceived = 8
 
     # Internal / scorbitd events
     _None = 1000

--- a/wrappers/python27/src/scorbit/_types.py
+++ b/wrappers/python27/src/scorbit/_types.py
@@ -12,6 +12,77 @@
 from __future__ import absolute_import
 
 
+class BundlePrice(object):
+    """A credit bundle with pricing.
+
+    Attributes:
+        credits: Number of credits in this bundle.
+        price: Effective price (sale or regular) as a decimal string.
+        regular_price: Non-discounted price as a decimal string.
+        sale_price: Discounted price as a decimal string, empty if no sale.
+    """
+
+    __slots__ = ("credits", "price", "regular_price", "sale_price")
+
+    def __init__(self, credits=0, price="", regular_price="", sale_price=""):
+        # type: (int, str, str, str) -> None
+        self.credits = credits
+        self.price = price
+        self.regular_price = regular_price
+        self.sale_price = sale_price
+
+    def __repr__(self):
+        # type: () -> str
+        return "BundlePrice(credits={0!r}, price={1!r})".format(
+            self.credits, self.price
+        )
+
+
+class PricingInfo(object):
+    """Pricing configuration for the machine.
+
+    Attributes:
+        free_play: Whether the machine is in free play mode.
+        payments_enabled: Whether payments are enabled.
+        credit_price: Effective price per credit as a decimal string.
+        credit_regular_price: Non-discounted price per credit.
+        credit_sale_price: Sale price per credit, empty if no sale.
+        bundles: List of :class:`BundlePrice` objects.
+    """
+
+    __slots__ = (
+        "free_play",
+        "payments_enabled",
+        "credit_price",
+        "credit_regular_price",
+        "credit_sale_price",
+        "bundles",
+    )
+
+    def __init__(
+        self,
+        free_play=False,
+        payments_enabled=False,
+        credit_price="",
+        credit_regular_price="",
+        credit_sale_price="",
+        bundles=None,
+    ):
+        # type: (bool, bool, str, str, str, list) -> None
+        self.free_play = free_play
+        self.payments_enabled = payments_enabled
+        self.credit_price = credit_price
+        self.credit_regular_price = credit_regular_price
+        self.credit_sale_price = credit_sale_price
+        self.bundles = bundles if bundles is not None else []
+
+    def __repr__(self):
+        # type: () -> str
+        return "PricingInfo(free_play={0!r}, payments_enabled={1!r}, credit_price={2!r}, bundles={3!r})".format(
+            self.free_play, self.payments_enabled, self.credit_price, len(self.bundles)
+        )
+
+
 class PlayerInfo(object):
     """Player profile information.
 

--- a/wrappers/python27/src/scorbit/event.py
+++ b/wrappers/python27/src/scorbit/event.py
@@ -19,7 +19,7 @@ from ctypes import POINTER, byref, c_bool, c_char_p, c_int, c_size_t, c_uint, c_
 
 from ._bindings import _lib
 from ._enums import EventType
-from ._types import PlayerInfo
+from ._types import BundlePrice, PlayerInfo, PricingInfo
 
 
 class Event(object):
@@ -84,19 +84,70 @@ class Event(object):
         return None
 
     # ------------------------------------------------------------------
-    # Config
+    # Pricing
     # ------------------------------------------------------------------
 
-    def get_config_payments_enabled(self):
-        """Extract the ``payments_enabled`` flag from a ``ConfigReceived`` event.
+    def _get_pricing_str(self, func):
+        out = c_char_p()
+        if func(self._ptr, byref(out)):
+            val = out.value
+            if isinstance(val, bytes):
+                val = val.decode("utf-8", "replace")
+            return val or ""
+        return ""
+
+    def _get_bundle_str(self, func, index):
+        out = c_char_p()
+        if func(self._ptr, c_int(index), byref(out)):
+            val = out.value
+            if isinstance(val, bytes):
+                val = val.decode("utf-8", "replace")
+            return val or ""
+        return ""
+
+    def get_pricing_received(self):
+        """Parse a ``PricingReceived`` event.
 
         Returns:
-            ``True`` / ``False``, or ``None`` if the event type does not match.
+            A :class:`PricingInfo` object, or ``None`` if the event type
+            does not match.
         """
-        enabled = c_bool(False)
-        if _lib.sb_event_config_payments_enabled(self._ptr, byref(enabled)):
-            return bool(enabled.value)
-        return None
+        free_play = c_bool(False)
+        if not _lib.sb_event_pricing_free_play(self._ptr, byref(free_play)):
+            return None
+
+        payments_enabled = c_bool(False)
+        _lib.sb_event_pricing_payments_enabled(self._ptr, byref(payments_enabled))
+
+        credit_price = self._get_pricing_str(_lib.sb_event_pricing_credit_price)
+        credit_regular = self._get_pricing_str(_lib.sb_event_pricing_credit_regular_price)
+        credit_sale = self._get_pricing_str(_lib.sb_event_pricing_credit_sale_price)
+
+        count = c_int(0)
+        _lib.sb_event_pricing_bundles_count(self._ptr, byref(count))
+        bundles = []
+        for i in range(count.value):
+            credits = c_int(0)
+            _lib.sb_event_pricing_bundle_credits(self._ptr, c_int(i), byref(credits))
+            bundles.append(BundlePrice(
+                credits=credits.value,
+                price=self._get_bundle_str(_lib.sb_event_pricing_bundle_price, i),
+                regular_price=self._get_bundle_str(_lib.sb_event_pricing_bundle_regular_price, i),
+                sale_price=self._get_bundle_str(_lib.sb_event_pricing_bundle_sale_price, i),
+            ))
+
+        return PricingInfo(
+            free_play=bool(free_play.value),
+            payments_enabled=bool(payments_enabled.value),
+            credit_price=credit_price,
+            credit_regular_price=credit_regular,
+            credit_sale_price=credit_sale,
+            bundles=bundles,
+        )
+
+    # ------------------------------------------------------------------
+    # Config
+    # ------------------------------------------------------------------
 
     def get_config_received(self):
         """Extract the config JSON string from a ``ConfigReceived`` event.


### PR DESCRIPTION
Introduces a dedicated PricingReceived event to handle machine pricing configuration, including free play status, payment availability, and credit/bundle pricing. This separates pricing logic from the general configuration event and provides helper accessors across C, C++, and Python APIs.
