### PR TITLE
refactor(python): rename py2 pypi package for explicit distribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,12 +75,13 @@ More compilers and OS will be added on request.
 
 ### Install Python SDK
 
-Minimum supported Python version is 3.8 (Python 2.7 wheels are also published as **`scorbit`** with a `py2-none-any` tag).
+Minimum supported Python version is 3.8. Python 2.7 uses a separate PyPI package **`scorbit-py2`** (`py2-none-any` wheel).
 
-The PyPI package is a **pure-Python** wrapper. Install it with pip, then install the **native** SDK for the same version from [GitHub releases](https://github.com/scorbit-io/scorbit_sdk/releases):
+The PyPI packages are **pure-Python** wrappers. Install with pip, then install the **native** SDK for the same version from [GitHub releases](https://github.com/scorbit-io/scorbit_sdk/releases):
 
 ```bash
-pip install scorbit==1.99.66
+pip install scorbit==1.99.66        # Python 3
+pip install scorbit-py2==1.99.66  # Python 2.7
 # Install native runtime from https://github.com/scorbit-io/scorbit_sdk/releases/tag/1.99.66
 # e.g. scorbit_sdk-1.99.66-arm64_u18.deb or .tar.gz (see arch / ABI tags above)
 ```

--- a/wrappers/python/README.md
+++ b/wrappers/python/README.md
@@ -1,8 +1,8 @@
-# Scorbit SDK - Python wrapper
+# Scorbit SDK - Python 3.6+
 
 Pure-Python wrapper for the [Scorbit SDK](https://scorbit.io) C library. Works on **Python 3.6+** with no compilation: it uses `ctypes` against the stable C ABI.
 
-> For Python 2.7, use [`wrappers/python27`](../python27/).
+> For Python 2.7, use [`wrappers/python27`](../python27/) (`pip install scorbit-py2` on PyPI).
 
 ## Native SDK required
 
@@ -25,7 +25,7 @@ Install the Scorbit SDK shared library on the system. The wrapper loads it in th
 ## Installation
 
 ```bash
-pip install scorbit==1.99.66
+pip install scorbit
 ```
 
 Then install the native SDK from the matching release, for example [1.99.66](https://github.com/scorbit-io/scorbit_sdk/releases/tag/1.99.66), and use the `.deb` or `.tar.gz` for your architecture and ABI tag (see the root [README](../../README.md)).

--- a/wrappers/python27/README.md
+++ b/wrappers/python27/README.md
@@ -1,4 +1,4 @@
-# Scorbit SDK - Python 2.7 wrapper
+# Scorbit SDK - Python 2.7
 
 Pure-Python wrapper for the [Scorbit SDK](https://scorbit.io) C library for **Python 2.7**. Uses `ctypes` against the stable C ABI; no compilation.
 
@@ -6,7 +6,7 @@ Pure-Python wrapper for the [Scorbit SDK](https://scorbit.io) C library for **Py
 
 ## Native SDK required
 
-`pip install scorbit` installs **only** the Python wrapper. Install the **native** shared library for the **same version** from [GitHub releases](https://github.com/scorbit-io/scorbit_sdk/releases). If the library is missing, `import scorbit` reports a version-matched release URL and suggested filenames.
+`pip install scorbit-py2` installs **only** the Python wrapper. Install the **native** shared library for the **same version** from [GitHub releases](https://github.com/scorbit-io/scorbit_sdk/releases). If the library is missing, `import scorbit` reports a version-matched release URL and suggested filenames.
 
 ## Prerequisites
 
@@ -31,7 +31,7 @@ Load order for the shared library:
 ## Installation
 
 ```bash
-pip install scorbit==1.99.66
+pip install scorbit-py2
 ```
 
 Then install the native SDK from the matching [GitHub release](https://github.com/scorbit-io/scorbit_sdk/releases/tag/1.99.66).
@@ -218,9 +218,9 @@ Same behavior as the Python 3 wrapper: C calls release the GIL; callbacks acquir
 | `enum.IntFlag` for `Capability` | Plain class with integer constants |
 | `requires-python >= 3.6` | `python_requires` 2.7 (not 3.x) |
 | No extra deps | `enum34` |
-| Wheel `py3-none-any` | Wheel `py2-none-any` |
+| PyPI **`scorbit`**, wheel `py3-none-any` | PyPI **`scorbit-py2`**, wheel `py2-none-any` |
 
-Both publish as **`scorbit`**; `pip` picks the wheel for the running interpreter.
+Import name is **`scorbit`** for both; only the pip package name differs.
 
 ## License
 

--- a/wrappers/python27/setup.py
+++ b/wrappers/python27/setup.py
@@ -23,7 +23,7 @@ with open(os.path.join(here, "README.md")) as f:
     long_description = f.read()
 
 setup(
-    name="scorbit",
+    name="scorbit-py2",
     version=version_ns["__version__"],
     description="Python 2.7 wrapper for the Scorbit SDK (pinball scoring platform)",
     long_description=long_description,

--- a/wrappers/python27/src/scorbit/_install_hints.py
+++ b/wrappers/python27/src/scorbit/_install_hints.py
@@ -178,7 +178,7 @@ def format_missing_library_message(version, lib_filename):
     return (
         "Cannot find the Scorbit SDK shared library ({0}).\n"
         "\n"
-        "Python package scorbit {1} requires the native SDK for this platform.\n"
+        "Python package scorbit-py2 {1} requires the native SDK for this platform.\n"
         "\n"
         "{2}"
         "Install from:\n"


### PR DESCRIPTION
Explicitly separates the Python 2.7 SDK on PyPI by renaming its package from `scorbit` to `scorbit-py2`. This clarifies installation for users and avoids potential conflicts when `scorbit` wheels for different Python versions exist. Updates all relevant documentation and install hints to reflect this change.
