### PR TITLE
fix(tpm): add randomized backoff for transient ATCA RX errors

### DIFF
--- a/libs/tpm/source/tpm.cpp
+++ b/libs/tpm/source/tpm.cpp
@@ -14,16 +14,42 @@
 #include <assert.h>
 #include <cstring>
 #include <functional>
+#include <random>
 #include <thread>
 
 using namespace std::chrono_literals;
 
 constexpr uint8_t SLB_I2C_BUS = 1;
 constexpr uint8_t SCORBITRON_V1_I2C_BUS = 0;
+
 constexpr auto MAX_RETRY_TIMES = 5;
+
 constexpr auto DELAY_BEFORE_RETRY = 20ms;
+constexpr auto RX_ERROR_RETRY_MIN_DELAY = 2s;
+constexpr auto RX_ERROR_RETRY_MAX_DELAY = 5s;
 
 namespace {
+
+bool shouldUseRxErrorRetryDelay(ATCA_STATUS status)
+{
+    return status == ATCA_RX_CRC_ERROR || status == ATCA_RX_FAIL;
+}
+
+std::chrono::milliseconds retryDelayForStatus(ATCA_STATUS status)
+{
+    if (!shouldUseRxErrorRetryDelay(status)) {
+        return DELAY_BEFORE_RETRY;
+    }
+
+    static thread_local std::mt19937 randomGenerator {std::random_device {}()};
+
+    std::uniform_int_distribution<int64_t> delayDistribution(
+            std::chrono::duration_cast<std::chrono::milliseconds>(RX_ERROR_RETRY_MIN_DELAY).count(),
+            std::chrono::duration_cast<std::chrono::milliseconds>(RX_ERROR_RETRY_MAX_DELAY)
+                    .count());
+
+    return std::chrono::milliseconds(delayDistribution(randomGenerator));
+}
 
 ATCA_STATUS atcaRetry(std::function<ATCA_STATUS()> func)
 {
@@ -33,9 +59,13 @@ ATCA_STATUS atcaRetry(std::function<ATCA_STATUS()> func)
         if (status == ATCA_SUCCESS) {
             return status;
         }
-        WRN("{}: error {}, retrying in {}ms...", __func__, static_cast<int>(status),
-            DELAY_BEFORE_RETRY.count());
-        std::this_thread::sleep_for(DELAY_BEFORE_RETRY);
+
+        if (i + 1 < MAX_RETRY_TIMES) {
+            const auto retryDelay = retryDelayForStatus(status);
+            WRN("{}: error {}, retrying in {}ms...", __func__, static_cast<int>(status),
+                retryDelay.count());
+            std::this_thread::sleep_for(retryDelay);
+        }
     }
     ERR("{}: error {}, giving up after {} retries...", __func__, static_cast<int>(status),
         MAX_RETRY_TIMES);


### PR DESCRIPTION
atcaRetry() now applies a randomized 2–5 second retry delay for ATCA_RX_CRC_ERROR and ATCA_RX_FAIL to reduce contention and improve recovery from transient communication failures.

Other ATCA errors retain the existing 20ms retry delay. The retry logic still performs up to 5 total attempts and now avoids sleeping after the final failed attempt.
