### PR TITLE
feat(config): add setLanIp + emit in scorbitron object (SB-3394)

### DIFF
--- a/include/scorbit_sdk/config.h
+++ b/include/scorbit_sdk/config.h
@@ -155,6 +155,25 @@ public:
     }
 
     /**
+     * @brief Set the device's LAN IP address.
+     *
+     * SB-3394 — the LAN IP is what the device sees on its own network interface
+     * (typically an RFC1918 address), distinct from the WAN-side address the API
+     * observes via the request. The SDK does not detect this itself; integrators
+     * supply it here and the SDK relays it to the API in the scorbitron-object
+     * PATCH at startup. Optional — leave unset on platforms / integrators that
+     * don't have a clean detection path.
+     *
+     * @param lanIp IPv4 or IPv6 string. Empty string is treated as "not set".
+     * @return Reference to this Config for method chaining.
+     */
+    Config &setLanIp(const std::string &lanIp)
+    {
+        sb_config_set_lan_ip(m_handle.get(), lanIp.c_str());
+        return *this;
+    }
+
+    /**
      * @brief Enable or disable automatic player picture downloads.
      * @param enable If true, player pictures are downloaded automatically.
      * @return Reference to this Config for method chaining.

--- a/include/scorbit_sdk/config_c.h
+++ b/include/scorbit_sdk/config_c.h
@@ -120,6 +120,25 @@ SCORBIT_SDK_EXPORT
 void sb_config_set_serial_number(sb_config_t config, uint64_t serial_number);
 
 /**
+ * @brief Set the device's LAN IP address.
+ *
+ * SB-3394 — the LAN IP is what the device sees on its own network interface
+ * (typically an RFC1918 address like 192.168.x.y), distinct from the WAN-side
+ * address the API observes via the request. The SDK does NOT detect this
+ * itself — the integrator (scorbitd on Linux via getifaddrs(), OEM platforms
+ * via their own method) supplies it here, and the SDK relays it to the API
+ * in the scorbitron-object PATCH at startup.
+ *
+ * Optional. Pass NULL or an empty string to leave it unset (legacy behavior;
+ * the API renders an em-dash on the Backstage diagnostic tab).
+ *
+ * @param config The configuration handle.
+ * @param lan_ip Null-terminated IP string (IPv4 or IPv6) or NULL to leave unset.
+ */
+SCORBIT_SDK_EXPORT
+void sb_config_set_lan_ip(sb_config_t config, const char *lan_ip);
+
+/**
  * @brief Enable or disable automatic player picture downloads.
  *
  * @param config The configuration handle.

--- a/source/config_c.cpp
+++ b/source/config_c.cpp
@@ -80,6 +80,13 @@ void sb_config_set_serial_number(sb_config_t config, uint64_t serial_number)
     }
 }
 
+void sb_config_set_lan_ip(sb_config_t config, const char *lan_ip)
+{
+    if (config) {
+        config->lanIp = lan_ip ? lan_ip : std::string {};
+    }
+}
+
 void sb_config_set_auto_download_player_pics(sb_config_t config, bool enable)
 {
     if (config) {

--- a/source/device_info.h
+++ b/source/device_info.h
@@ -47,6 +47,12 @@ struct DeviceInfo {
     std::string cfHostname;
     std::string uuid;
     uint64_t serialNumber {0};
+    // SB-3394 — LAN IP of the device's primary network interface. The SDK
+    // does NOT detect this itself (cross-platform networking is the
+    // integrator's job — getifaddrs on Linux, GetAdaptersAddresses on
+    // Windows, etc.); scorbitd / OEM integrators call setLanIp() and the
+    // SDK relays the value in initScorbitronObject. Empty = not set.
+    std::string lanIp;
     bool autoDownloadPlayerPics {false};
     std::vector<std::string> scoreFeatures;
     int scoreFeaturesVersion {0};

--- a/source/identifiers.h
+++ b/source/identifiers.h
@@ -166,6 +166,10 @@ constexpr auto JKEY_SOBJ_GAME_CODE_VERSION {"game_code_version"};
 constexpr auto JKEY_SOBJ_START_GAME_CAPABLE {"start_game_capable"};
 constexpr auto JKEY_SOBJ_NFC_CAPABLE {"nfc_capable"};
 constexpr auto JKEY_SOBJ_CREDIT_DROP_CAPABLE {"credit_drop_capable"};
+// SB-3394 — LAN IP supplied by the integrator via Config::setLanIp(). Distinct
+// from the WAN-side IP the API observes on the request; useful for "did the
+// device get a DHCP lease" debugging on the Backstage diagnostic tab.
+constexpr auto JKEY_SOBJ_LAN_IP {"lan_ip"};
 
 constexpr auto JKEY_SOBJ_RELEASE_TRACK {"release_track"};
 constexpr auto JKEY_SOBJ_RELEASE_URL {"url"};

--- a/source/net.cpp
+++ b/source/net.cpp
@@ -1784,6 +1784,14 @@ void Net::initScorbitronObject()
     m_scorbitronObject[JKEY_SOBJ_NFC_CAPABLE] = m_isNfcCapable;
     m_scorbitronObject[JKEY_SOBJ_START_GAME_CAPABLE] = false;
     m_scorbitronObject[JKEY_SOBJ_CREDIT_DROP_CAPABLE] = false;
+
+    // SB-3394 — only emit the LAN IP when the integrator supplied one. The
+    // API serializer validates as IPAddressField; sending an empty string
+    // would fail validation, and leaving the key off matches the legacy
+    // shape that older API releases handle as null.
+    if (!m_deviceInfo.lanIp.empty()) {
+        m_scorbitronObject[JKEY_SOBJ_LAN_IP] = m_deviceInfo.lanIp;
+    }
 }
 
 void Net::sendScorbitronObject()


### PR DESCRIPTION
## Summary

SB-3394 §3b — adds `Config::setLanIp()` / `sb_config_set_lan_ip()` so SDK integrators (scorbitd today, OEM platforms later) can supply the device's LAN IP. The SDK relays it to the API in the scorbitron-object PATCH at startup; the API surfaces it on the Backstage diagnostic tab pre-flight panel.

Companion: [scorbit-io/api#3143](https://github.com/scorbit-io/api/pull/3143) ships the API column + migration + serializer + pre-flight payload exposure. Linear: [SB-3394](https://linear.app/scorbit/issue/SB-3394).

## Architectural decision

The SDK does NOT detect the LAN IP itself. Cross-platform network discovery (`getifaddrs()` on Linux, `GetAdaptersAddresses()` on Windows, etc.) is the integrator's job. This matches the existing `Config::setScorbitdVersion()` / `setScorbitdPlatformId()` / `setSerialNumber()` pattern: the integrator provides platform-specific values, the SDK relays them in `initScorbitronObject`.

Reasons (from the eng_docs plan):
- Keeps the SDK platform-agnostic — it builds for armhf / arm64 / macOS / Python wheels / potentially Windows for OEMs.
- Each OEM integrator decides their own detection strategy (or skips entirely if they don't want LAN IP visibility).
- No new platform-specific networking code in the SDK.

## Files changed

| File | Change |
|---|---|
| `source/device_info.h` | +`lanIp` string field on `DeviceInfo` |
| `include/scorbit_sdk/config_c.h` | +`sb_config_set_lan_ip` C-ABI declaration alongside `sb_config_set_serial_number` |
| `source/config_c.cpp` | +`sb_config_set_lan_ip` C-ABI implementation (mirrors `set_serial_number`) |
| `include/scorbit_sdk/config.h` | +`Config::setLanIp(const std::string&)` method delegating to the C-ABI |
| `source/identifiers.h` | +`JKEY_SOBJ_LAN_IP` next to other `JKEY_SOBJ_*` keys |
| `source/net.cpp` | Emit `JKEY_SOBJ_LAN_IP` in `Net::initScorbitronObject` only when non-empty (avoids sending empty string that the API's `IPAddressField` would reject) |

Net: +63 lines, -0.

## Companion PRs

- **API side (in review):** [scorbit-io/api#3143](https://github.com/scorbit-io/api/pull/3143) — adds `Scorbitron.lan_ip` column + migration + writable serializer override + preflight payload exposure.
- **scorbitd side (pending, separate scorbitd PR):** detects the LAN IP via `getifaddrs()` and calls `gameConfig.setLanIp(detectedIp)` in `MainController::setupSDK()` alongside `setScorbitdVersion()` / `setPlatformId()` / `setSerialNumber()`.

Until scorbitd ships the detection PR, this setter is dormant in production — the field stays empty on devices and the API renders an em-dash. That is the correct legacy fallback.

## Notable decisions (open for review)

1. **Only emit when non-empty.** `Net::initScorbitronObject` skips the `JKEY_SOBJ_LAN_IP` key when `m_deviceInfo.lanIp` is empty rather than sending an empty string. The API serializer ([scorbit-io/api#3143](https://github.com/scorbit-io/api/pull/3143)) declares `lan_ip` as `IPAddressField(allow_null=True, required=False)` — empty string would fail validation. Missing key = null, which is the correct legacy shape.

2. **Public Config API placement.** `setLanIp()` lives in the public block (alongside `setUuid` / `setSerialNumber` / `setAutoDownloadPlayerPics`), NOT in the "internal use only - for scorbitd" block at the bottom (`setScorbitdVersion`, `setScorbitdPlatformId`). LAN IP is a device characteristic any OEM integrator might want to provide, not scorbitd-specific.

3. **No new tests.** `test_net.cpp` continues the minimal-coverage precedent set by `setSerialNumber` / `setScorbitdVersion` / etc. — those have no unit tests either. Adding a `setLanIp` test alone without a mocked Centrifugo client would be an arbitrary point of coverage. Staging smoke after scorbitd lands the detection PR is the validation path.

4. **VERSION untouched.** Per the eng_docs plan, version bumps / release tags are handled in a separate release PR (Dilshod's release cadence). This PR is the feature-only diff.

## Verification

Local build on macOS / clang++ / C++20:

```sh
cmake --build build/local --target scorbit_sdk -j
```

Exit 0. `libscorbit_sdk.dylib` linked clean. No warnings on the six touched files.

## Related

- Part of: [SB-3357](https://linear.app/scorbit/issue/SB-3357) (Scorbit Diagnostic Trace epic)
- Companion: [SB-3394 §3a — api#3143](https://github.com/scorbit-io/api/pull/3143)
- Sibling SDK PR: [SB-3363 — scorbit_sdk#170](https://github.com/scorbit-io/scorbit_sdk/pull/170) (diag_probe handler) — independent feature, both ride next SDK release
- Implementation plan: [eng_docs/plans/scorbitd_diagnostic_implementation_plan.md](https://github.com/scorbit-io/eng_docs/blob/main/plans/scorbitd_diagnostic_implementation_plan.md)