### PR TITLE
feat(net): include local LAN IP in scorbitron object

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -221,6 +221,8 @@ target_sources(
         source/utils/jwt_parser.cpp
         source/utils/archiver.h
         source/utils/archiver.cpp
+        source/utils/lan_ip.h
+        source/utils/lan_ip.cpp
         include/scorbit_sdk/player_info.h
         source/player_profiles_manager.h
         source/player_profiles_manager.cpp

--- a/source/identifiers.h
+++ b/source/identifiers.h
@@ -179,6 +179,7 @@ constexpr auto JKEY_SOBJ_START_GAME_CAPABLE {"start_game_capable"};
 constexpr auto JKEY_SOBJ_NFC_CAPABLE {"nfc_capable"};
 constexpr auto JKEY_SOBJ_CREDIT_DROP_CAPABLE {"credit_drop_capable"};
 constexpr auto JKEY_SOBJ_DIAG_PROBE_CAPABLE {"diag_probe_capable"};
+constexpr auto JKEY_SOBJ_LAN_IP {"lan_ip"};
 
 constexpr auto JKEY_SOBJ_RELEASE_TRACK {"release_track"};
 constexpr auto JKEY_SOBJ_RELEASE_URL {"url"};

--- a/source/net.cpp
+++ b/source/net.cpp
@@ -28,6 +28,7 @@
 #include "utils/date_time_parser.h"
 #include "utils/jwt_parser.h"
 #include "utils/archiver.h"
+#include "utils/lan_ip.h"
 #include <utils/bytearray.h>
 #include <scorbit_sdk/net_types.h>
 #include <scorbit_sdk/version.h>
@@ -1899,6 +1900,10 @@ void Net::initScorbitronObject()
     // SB-3363 — handler ships unconditionally; advertise so the API can gate
     // probe dispatch on this bool and avoid timing out old-SDK devices.
     m_scorbitronObject[JKEY_SOBJ_DIAG_PROBE_CAPABLE] = true;
+
+    if (const auto lanIp = getPrimaryLanIp(); !lanIp.empty()) {
+        m_scorbitronObject[JKEY_SOBJ_LAN_IP] = lanIp;
+    }
 }
 
 void Net::sendScorbitronObject()

--- a/source/utils/lan_ip.cpp
+++ b/source/utils/lan_ip.cpp
@@ -1,0 +1,101 @@
+/*
+ * Scorbit SDK
+ *
+ * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scrobit.io, All Rights Reserved
+ *
+ * MIT License
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include "lan_ip.h"
+#include <boost/asio/io_context.hpp>
+#include <boost/asio/ip/udp.hpp>
+#include <boost/system/error_code.hpp>
+#include <array>
+#include <cstdint>
+
+namespace scorbit {
+namespace detail {
+namespace {
+
+using boost::asio::ip::address;
+using boost::asio::ip::make_address;
+using boost::asio::ip::udp;
+
+bool isIpv4LinkLocal(const boost::asio::ip::address_v4 &address)
+{
+    constexpr std::uint32_t linkLocalPrefix = 0xA9FE0000; // 169.254.0.0
+    constexpr std::uint32_t linkLocalMask = 0xFFFF0000;
+    return (address.to_uint() & linkLocalMask) == linkLocalPrefix;
+}
+
+std::string getLanIpForDefaultRoute(const address &routeTarget)
+{
+    boost::system::error_code ec;
+    boost::asio::io_context ioContext;
+    udp::socket socket(ioContext);
+
+    socket.open(routeTarget.is_v4() ? udp::v4() : udp::v6(), ec);
+    if (ec) {
+        return {};
+    }
+
+    socket.connect(udp::endpoint(routeTarget, 53), ec);
+    if (ec) {
+        return {};
+    }
+
+    const auto localEndpoint = socket.local_endpoint(ec);
+    if (ec || !isUsableLanAddress(localEndpoint.address())) {
+        return {};
+    }
+
+    return localEndpoint.address().to_string();
+}
+
+} // namespace
+
+bool isUsableLanAddress(const address &address)
+{
+    if (address.is_unspecified() || address.is_loopback() || address.is_multicast()) {
+        return false;
+    }
+
+    if (address.is_v4()) {
+        return !isIpv4LinkLocal(address.to_v4());
+    }
+
+    const auto v6Address = address.to_v6();
+    return !v6Address.is_link_local();
+}
+
+std::string getPrimaryLanIp()
+{
+    const std::array targets {
+            make_address("8.8.8.8"),
+            make_address("1.1.1.1"),
+            make_address("2001:4860:4860::8888"),
+            make_address("2606:4700:4700::1111"),
+    };
+
+    for (const auto &target : targets) {
+        if (const auto lanIp = getLanIpForDefaultRoute(target); !lanIp.empty()) {
+            return lanIp;
+        }
+    }
+
+    return {};
+}
+
+} // namespace detail
+} // namespace scorbit

--- a/source/utils/lan_ip.h
+++ b/source/utils/lan_ip.h
@@ -1,0 +1,32 @@
+/*
+ * Scorbit SDK
+ *
+ * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scrobit.io, All Rights Reserved
+ *
+ * MIT License
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#pragma once
+
+#include <boost/asio/ip/address.hpp>
+#include <string>
+
+namespace scorbit {
+namespace detail {
+
+bool isUsableLanAddress(const boost::asio::ip::address &address);
+std::string getPrimaryLanIp();
+
+} // namespace detail
+} // namespace scorbit

--- a/tests/test_detail/CMakeLists.txt
+++ b/tests/test_detail/CMakeLists.txt
@@ -118,6 +118,9 @@ target_sources(
         ../../source/utils/mac_address.h
         ../../source/utils/mac_address.cpp
         source/test_mac_address.cpp
+        ../../source/utils/lan_ip.h
+        ../../source/utils/lan_ip.cpp
+        source/test_lan_ip.cpp
         ../../source/utils/machine_fingerprint.h
         ../../source/utils/machine_fingerprint.cpp
         source/test_machine_fingerprint.cpp

--- a/tests/test_detail/source/test_lan_ip.cpp
+++ b/tests/test_detail/source/test_lan_ip.cpp
@@ -1,0 +1,58 @@
+/*
+ * Scorbit SDK
+ *
+ * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scrobit.io, All Rights Reserved
+ *
+ * MIT License
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include "utils/lan_ip.h"
+#include <catch2/catch_test_macros.hpp>
+#include <boost/asio/ip/address.hpp>
+
+// clazy:excludeall=non-pod-global-static
+
+using namespace scorbit::detail;
+using boost::asio::ip::make_address;
+
+TEST_CASE("LAN IP filter rejects non-routable addresses", "[lan_ip]")
+{
+    CHECK_FALSE(isUsableLanAddress(make_address("0.0.0.0")));
+    CHECK_FALSE(isUsableLanAddress(make_address("127.0.0.1")));
+    CHECK_FALSE(isUsableLanAddress(make_address("169.254.1.2")));
+    CHECK_FALSE(isUsableLanAddress(make_address("224.0.0.1")));
+
+    CHECK_FALSE(isUsableLanAddress(make_address("::")));
+    CHECK_FALSE(isUsableLanAddress(make_address("::1")));
+    CHECK_FALSE(isUsableLanAddress(make_address("fe80::1")));
+    CHECK_FALSE(isUsableLanAddress(make_address("ff02::1")));
+}
+
+TEST_CASE("LAN IP filter accepts routable addresses", "[lan_ip]")
+{
+    CHECK(isUsableLanAddress(make_address("192.168.1.42")));
+    CHECK(isUsableLanAddress(make_address("10.0.0.5")));
+    CHECK(isUsableLanAddress(make_address("172.16.0.5")));
+    CHECK(isUsableLanAddress(make_address("2001:db8::1")));
+}
+
+TEST_CASE("Primary LAN IP discovery returns usable address when available", "[lan_ip]")
+{
+    const auto lanIp = getPrimaryLanIp();
+    if (!lanIp.empty()) {
+        CHECK(isUsableLanAddress(make_address(lanIp)));
+    } else {
+        WARN("Primary LAN IP could not be discovered, likely due to missing default route");
+    }
+}


### PR DESCRIPTION
Adds a utility to discover the primary LAN IP address via default routes and includes it in the network state object during initialization.
