### PR TITLE
fix(achievements): read group_id under the key the v2 API emits

### DIFF
--- a/source/identifiers.h
+++ b/source/identifiers.h
@@ -145,7 +145,7 @@ constexpr auto JKEY_ACH_INPUT_TIME {"input_time"};
 constexpr auto JKEY_ACH_VISIBLE {"visible"};
 constexpr auto JKEY_ACH_NOTIFY {"notify_when_achieved"};
 constexpr auto JKEY_ACH_IS_TROPHY {"is_trophy"};
-constexpr auto JKEY_ACH_GROUP_ID {"groupid"};
+constexpr auto JKEY_ACH_GROUP_ID {"group_id"};
 constexpr auto JKEY_ACH_ACHIEVEMENT_ID {"achievementid"};
 constexpr auto JKEY_ACH_TRIGGER {"trigger"};
 constexpr auto JKEY_ACH_MODE_NAME {"mode_name"};


### PR DESCRIPTION
## Summary

- `JKEY_ACH_GROUP_ID` was defined as `"groupid"` (the v1-era spelling), but the v2 `ScorbitronAchievementSerializer` emits `"group_id"`, so the lookup missed on every achievement and `Achievement.groupId` silently fell back to `0`.
- Renames the SDK-side key to match the API. On-device achievement grouping and levels were inert before this.

## Details

`nlohmann::json::value(key, default)` returns the default for an absent key rather than throwing, so the miss produced no error and no log line — only wrong data.

The constant has a single consumer, `source/net.cpp:2205`. The C++ symbol `JKEY_ACH_GROUP_ID` and the struct member `groupId` are unchanged; only the wire-format string differs, so there is no call-site or ABI impact.

This is the narrower of the two available fixes. Aliasing `groupid` onto the serializer would instead alter a shipped v2 API response that the Creator Portal and other v2 clients already consume.

Two notes for the reviewer:

- Base branch is `feature/v2_achievements_module` rather than `main`. The achievement module does not exist on `main`, so the conventional base is unavailable for this change.
- No automated test covers this. The achievement module currently has no unit tests, so the fix is verified by inspection of the serializer field list against the parser.

FIXES: SB-4063