### PR TITLE
docs: add agent governance documents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,24 @@
+# Agent Operating Protocol — scorbit_sdk
+
+This repo's agent instructions live in three tracked files. Read them in this order:
+
+| File | Contents |
+|------|----------|
+| **[CLAUDE.md](CLAUDE.md)** | Start here. Environment, quality gates, pre-implementation checklist, known repo state, long-lived branches. |
+| **[AGENT_CONVENTIONS.md](AGENT_CONVENTIONS.md)** | RFC 2119 coding standards: build system, C++/C style, the mandatory dual C++/C API pattern, identifiers, testing, packaging, Git/PR rules. |
+| **[SDLC.md](SDLC.md)** | Delivery process: planning cadence, story standard, Definition of Done, release pipeline, hotfix rules, branch hygiene. |
+
+## The five rules most often broken here
+
+1. **Never build in-source.** `cmake -B build -S .` — CMake hard-fails otherwise.
+2. **Public API means both C++ and C**, plus Python `ctypes` bindings and example updates, in the
+   same PR. The C ABI is a contract with deployed machines.
+3. **A new test file is not compiled** until it is explicitly listed in the relevant
+   `tests/*/CMakeLists.txt`. Verify your test actually ran.
+4. **There is no PR-gating CI** — five of seven workflows are disabled and broken. Build, run
+   `ctest`, and paste the output into the PR. Never claim "CI green."
+5. **No URLs or JSON keys as inline literals.** They go in `source/identifiers.h`.
+
+> The older `AGENTS.md` and `AGENT_CONVENTIONS.md` on the unmerged `feature/achievements-module`
+> branch are **stale** — they document C++17, Google Test, FetchContent, and a
+> `scripts/u20-build.sh` that no longer exists. The files above supersede them.

--- a/AGENT_CONVENTIONS.md
+++ b/AGENT_CONVENTIONS.md
@@ -1,0 +1,578 @@
+# Project Governance & Conventions (RFC 2119) — scorbit_sdk (C/C++/Python)
+
+> **Cross-stack rules** (branch naming, Conventional Commits, PR standards, Linear
+> lifecycle, governance distribution) follow canonical upstream:
+> [scorbit-io/eng_docs `_shared/AGENT_CONVENTIONS.md`](https://github.com/scorbit-io/eng_docs/blob/main/governance/_shared/AGENT_CONVENTIONS.md).
+> This file contains scorbit_sdk-specific rules only.
+
+The key words "MUST", "MUST NOT", "SHOULD", "SHOULD NOT", and "MAY" are interpreted per RFC 2119.
+
+---
+
+## 0. Development Environment (CRITICAL)
+
+The SDK is a **C++20** library with a **C ABI** and **pure-Python (ctypes)** wrappers. It is
+cross-compiled for Linux (armhf/arm64/amd64) inside Docker, and built natively on macOS for
+development.
+
+### 0.1. Running Commands
+
+| Task | Command | NEVER Use |
+|------|---------|-----------|
+| Build all release artifacts | `make all` | ad-hoc `cmake` invocations for release output |
+| Build one Linux arch | `make armhf` / `make arm64` / `make amd64` | host `cmake` (wrong ABI/glibc) |
+| Build macOS (dev only) | `make macos` | — |
+| Build Python 3 wheel | `make python` | `pip wheel wrappers/python` (version comes from repo `VERSION`) |
+| Build Python 2.7 wheel | `make python27` | — |
+| Cut a release branch | `make release` | hand-editing `VERSION` on `main` |
+| Remove build artifacts | `make clean` | `rm -rf build` (drops the CPM cache) |
+| Local dev build | `cmake -B build -S . -DCMAKE_BUILD_TYPE=Debug -G Ninja && cmake --build build` | in-source builds (CMake hard-fails) |
+| Run tests | `ctest --test-dir build --output-on-failure` | running test binaries directly |
+| Format C/C++ | `clang-format -i <files>` | reformatting unrelated files |
+| Format CMake | `./scripts/format-cmakelists.sh` | `cmake-format` (project uses gersemi) |
+
+Linux builds run inside `dilshodm/gcc-builder:$(cat DOCKER_RELEASE)`; Python wheels run inside
+`dilshodm/python-builder:$(cat DOCKER_RELEASE)`. `SCORBIT_PYTHON_NO_DOCKER=1 make python` builds
+the wheel on the host Python when Docker is unavailable.
+
+### 0.2. Absolute Prohibitions
+
+- **NEVER** perform an in-source build — CMake fails with `In-source builds not allowed`.
+- **NEVER** bump `VERSION` outside the `make release` flow (see §6).
+- **NEVER** commit build output. `encrypt_tool/encrypt_tool`, `build/`, and `build-*/` are
+  artifacts; `encrypt_tool/encrypt_tool` is **not** currently covered by `.gitignore` — do not
+  `git add` it.
+- **NEVER** commit or log `SCORBIT_SDK_ENCRYPT_SECRET`, provider private keys, or machine tokens.
+- **NEVER** change the C ABI (`include/scorbit_sdk/*_c.h`) without a major/minor version bump —
+  consumers link against `libscorbit_sdk.so.<major>`.
+
+### 0.3. Quick Reference
+
+```bash
+cmake -B build -S . -DCMAKE_BUILD_TYPE=Debug -G Ninja   # configure dev build
+cmake --build build -j                                   # build
+ctest --test-dir build --output-on-failure                # run unit tests
+cmake -B build-all -S all -G Ninja                        # configure the IDE-wide superproject
+clang-format -i source/net.cpp source/net.h               # format changed C/C++ files
+./scripts/format-cmakelists.sh                            # format CMakeLists via gersemi
+make arm64                                                # cross-build arm64 release artifacts
+```
+
+### 0.4. Key CMake Options
+
+| Option | Values | Meaning |
+|--------|--------|---------|
+| `SCORBIT_SDK_PRODUCTION` | `ON`/`OFF` (default `OFF`) | Production build for distribution. Requires `SCORBIT_SDK_ABI`. |
+| `SCORBIT_SDK_SHARED` | `ON`/`OFF` (default `ON`) | Shared vs. static library. Component packaging only applies when `ON`. |
+| `SCORBIT_SDK_ABI` | `u12`, `u12dev`, `u18`, `u20`, `macos`, `unknown` | ABI tag baked into the platform ID and artifact names. `u12`/`u12dev` additionally link `-static-libstdc++`. |
+| `SCORBIT_LOGGER` | `callback` (default), `spdlog` | Logger backend. `callback` compiles `source/log_c.cpp`; `spdlog` compiles `source/log_c_stub.cpp` and defines `SCORBIT_LOGGER_SPDLOG`. |
+| `ENABLE_TEST_COVERAGE` | `ON`/`OFF` | gcov instrumentation for the test targets. |
+| `TEST_INSTALLED_VERSION` | `ON`/`OFF` | Test against an installed `find_package(scorbit_sdk)` instead of the source tree. `test_detail` is skipped in this mode. |
+
+Install prefix is fixed to **`/opt/scorbit`** (`SCORBIT_SDK_INSTALL_PREFIX`); `CMAKE_INSTALL_LIBDIR`
+is forced to `lib`. Do not override these — the DEB maintainer scripts, `ld.so.conf.d` entry, and
+the self-update path all assume that layout.
+
+---
+
+## 1. Project Structure & Architecture
+
+```
+scorbit_sdk/
+├── include/scorbit_sdk/   # PUBLIC API surface (installed). *_c.h = C API, *.h = C++ API
+├── source/                # Private implementation (never installed)
+│   ├── utils/             # Leaf helpers: mac_address, lan_ip, jwt_parser, archiver, decrypt, ...
+│   ├── identifiers.h      # ALL URL / JSON-key / channel constants
+│   └── event_classes.h    # Event class hierarchy
+├── libs/                  # Vendored in-repo sub-libraries: logger, tpm, nfc, utils
+├── cmake/                 # CPM, packaging, arch detection, encryption, patches
+├── scripts/               # Build/release shell scripts
+├── tests/                 # test_detail (internals), test_interface (C++ API), test_interface_c (C API), test_python
+├── examples/              # c_example, cpp_example, python_example, python27_example
+├── wrappers/              # python (py3), python27 — pure-Python ctypes bindings
+├── encrypt_tool/          # Standalone key-encryption tool, packaged separately
+├── assets/                # certs/cacert.pem, deb/ maintainer scripts, scripts/ helpers
+├── all/                   # Superproject that adds every subdirectory (IDE convenience only)
+└── documentation/         # Doxygen configuration
+```
+
+### 1.1. Header Visibility
+
+| Location | Purpose | Installed? |
+|----------|---------|-----------|
+| `include/scorbit_sdk/*.h` | Public C++ API | YES — `scorbit_sdk-dev` package |
+| `include/scorbit_sdk/*_c.h` | Public C API | YES — `scorbit_sdk-dev` package |
+| `source/**/*.h`, `source/**/*.hpp` | Private implementation | NO |
+| `libs/*/include/**` | Sub-library headers | NO (linked `PRIVATE`, symbols hidden) |
+
+- Adding a file to `include/scorbit_sdk/` changes the shipped API surface. It MUST be listed in
+  the root `CMakeLists.txt` `target_sources()` block and reviewed as an API change.
+- The library builds with `CXX_VISIBILITY_PRESET hidden` and `-Wl,--exclude-libs,ALL` (GNU) /
+  `-Wl,-dead_strip` (Darwin). Anything intended for export MUST use the generated export macros.
+
+### 1.2. Where Does This Code Belong?
+
+| If you are writing… | It MUST go in… | NOT in… |
+|---------------------|----------------|---------|
+| Public C++ API | `include/scorbit_sdk/<feature>.h` | `source/` |
+| Public C API | `include/scorbit_sdk/<feature>_c.h` | `source/` |
+| C wrapper implementation | `source/<feature>_c.cpp` | `include/` |
+| Private implementation | `source/<feature>.{h,cpp}` | `include/` |
+| Leaf utility with no SDK deps | `source/utils/` | `source/` root |
+| URL, JSON key, channel name, literal value | `source/identifiers.h` | inline string literals |
+| Event class definition | `source/event_classes.h` | other files |
+| Reusable, independently testable subsystem | `libs/<name>/` | `source/` |
+
+---
+
+## 2. C++ Coding Standards
+
+### 2.1. Language Standard
+
+- **C++20** MUST be used (`CMAKE_CXX_STANDARD 20`, `CXX_STANDARD_REQUIRED ON`).
+- Public **C** headers MUST remain valid C99 and MUST be wrapped in `extern "C"` guards.
+- Code MUST compile clean with `-Wall -Wpedantic -Wextra -Werror` (enabled by the test targets on
+  GCC/Clang). Warnings are build failures.
+
+### 2.2. Style & Formatting
+
+- **Formatter:** `clang-format` using the repo `.clang-format` (Qt/WebKit-derived).
+- **Column limit:** 100 characters.
+- **Pinned version:** `clang-format==14.0.6` (as pinned in `.github/workflows/style.yml`). Newer
+  versions reflow code differently — do not reformat the tree with an unpinned binary.
+- `SortIncludes` is **disabled**. Include order is maintained by hand (see §2.5).
+- **CMake files:** formatted with `gersemi` per `.gersemirc` (indent 4, line length 100). Run
+  `./scripts/format-cmakelists.sh`.
+- Agents MUST format only the files they changed. Bulk reformatting is FORBIDDEN in a feature PR.
+
+### 2.3. Naming Conventions
+
+| Element | Convention | Example |
+|---------|------------|---------|
+| Classes / structs | PascalCase | `GameState`, `EventManager`, `Worker` |
+| Enum types and enumerators | PascalCase | `AuthStatus::Authenticated`, `Worker::Timer::Heartbeat` |
+| Functions / methods | camelCase | `setScore()`, `getPlayerInfo()` |
+| Local variables / parameters | camelCase | `sessionData`, `threadNiceValue` |
+| Member variables | `m_` + camelCase | `m_sessionUuid`, `m_isAuthenticated` |
+| Compile-time constants | UPPER_SNAKE_CASE | `URL_SCORBITRON_TOKEN`, `JKEY_PLAYER_ID` |
+| Namespaces | lowercase | `scorbit`, `scorbit::detail` |
+| File names | snake_case | `game_state.cpp`, `player_profiles_manager.h` |
+| C types | `sb_` prefix, `_t` suffix | `sb_game_handle_t`, `sb_event_type_t` |
+| C functions | `sb_` prefix, snake_case | `sb_event_type()`, `sb_config_set_lan_ip()` |
+| C enum values | `SB_` prefix, UPPER_SNAKE | `SB_EVT_ACHIEVEMENT_UNLOCKED` |
+
+### 2.4. Namespaces
+
+```cpp
+namespace scorbit {
+namespace detail {
+// internal implementation
+} // namespace detail
+} // namespace scorbit
+```
+
+- Public API MUST live in `scorbit`.
+- Internal implementation MUST live in `scorbit::detail`.
+- Closing braces MUST carry a `// namespace <name>` comment.
+- `NamespaceIndentation: None` — namespace bodies are not indented.
+
+### 2.5. Include Order
+
+Groups separated by a blank line, in this order (clang-format will not reorder them for you):
+
+```cpp
+#include "my_class.h"            // 1. corresponding header (.cpp only)
+
+#include <scorbit_sdk/game_state.h>   // 2. project headers
+#include "internal_helper.h"
+
+#include <boost/asio/strand.hpp>      // 3. third-party
+#include <fmt/format.h>
+
+#include <string>                     // 4. standard library
+#include <vector>
+```
+
+### 2.6. Error Handling & Logging
+
+- Exceptions MUST NOT cross the C ABI boundary. Every `source/*_c.cpp` entry point MUST catch and
+  translate to an `sb_error_t`.
+- Prefer error codes and callbacks over exceptions at API boundaries.
+- Internal diagnostics MUST use the logger macros from `libs/logger`: `DBG()`, `INF()`, `WRN()`,
+  `ERR()`. Do not use `printf`, `std::cout`, or `fmt::print` for runtime logging.
+- Network and hardware (TPM/NFC) failures MUST degrade gracefully — the SDK runs unattended inside
+  a pinball machine and MUST NOT abort the host process.
+- Blocking network or hardware calls MUST NOT be made from inside a user callback.
+
+### 2.7. Concurrency
+
+- Async work MUST be scheduled through `scorbit::detail::Worker` (Boost.Asio `io_context` +
+  strand). Do not spawn raw `std::thread` in SDK code.
+- Recurring work MUST use a named entry in `Worker::Timer`. New timers MUST be added **before**
+  the `Count` sentinel.
+- Shared mutable state accessed from more than one strand/thread MUST be documented and guarded.
+
+---
+
+## 3. Dual API Pattern (C++ and C) — MANDATORY
+
+Every public feature MUST ship both a C++ and a C surface, in the same PR.
+
+```
+include/scorbit_sdk/feature.h     C++ API — classes, RAII, std types
+include/scorbit_sdk/feature_c.h   C  API — opaque handles, POD, extern "C"
+source/feature.cpp                C++ implementation
+source/feature_c.cpp              C wrapper delegating to the C++ implementation
+```
+
+| C++ type | C type |
+|----------|--------|
+| `scorbit::GameState` | `sb_game_handle_t` |
+| `scorbit::EventType` | `sb_event_type_t` |
+| `scorbit::Error` | `sb_error_t` |
+| `scorbit::AuthStatus` | `sb_auth_status_t` |
+
+Rules:
+- C++ enum values MUST be defined **in terms of** their C counterparts so the two cannot drift:
+  `enum class EventType { NewEvent = SB_EVT_NEW_EVENT };`
+- The C API MUST NOT leak ownership ambiguity: any pointer handed to the caller MUST have a
+  documented lifetime, and any allocation MUST have a matching `sb_*_free`/destroy call.
+- The Python wrappers (`wrappers/python`, `wrappers/python27`) bind the **C** API via `ctypes`.
+  A new C entry point is not usable from Python until `_bindings.py` declares its `argtypes` and
+  `restype`. Adding a C function without the binding is incomplete work.
+
+### 3.1. Adding a New Event Type (7 steps, in order)
+
+1. Add the C enum value → `include/scorbit_sdk/event_types_c.h`
+2. Add the C++ enum value (aliased to the C value) → `include/scorbit_sdk/event_types.h`
+3. Create the event class → `source/event_classes.h`
+4. Declare the C helper → `include/scorbit_sdk/event_helpers_c.h`
+5. Implement the C helper → `source/event_helpers_c.cpp`
+6. Add the C++ accessor → `include/scorbit_sdk/event.h`
+7. Update **all four** examples and add a `tests/test_detail/source/test_event_*.cpp` case
+
+---
+
+## 4. Network, Provisioning & Identifiers
+
+### 4.1. Identifier Constants
+
+All URLs, JSON keys, JSON literal values, and Centrifugo channel names MUST be `constexpr auto`
+constants in `source/identifiers.h`. Inline string literals for these are FORBIDDEN.
+
+| Prefix | Meaning | Example |
+|--------|---------|---------|
+| `URL_*` | REST endpoint path, `/api` prefix included | `URL_SCORBITRON_TOKEN` |
+| `ARG_*` | `fmt` named-argument key used in a URL template | `ARG_SCORBITRON_UUID` |
+| `JKEY_*` | JSON object key | `JKEY_PLAYER_ID` |
+| `JVAL_*` | JSON literal value | `JVAL_CHN_TYPE_START_GAME` |
+| `CF_CHN_*` | Centrifugo channel name/prefix | `CF_CHN_MACHINE` |
+
+URL templates use `fmt::arg()` named substitution — positional substitution is FORBIDDEN.
+
+### 4.2. API Versioning
+
+New endpoints MUST target `api/v2/`. The `/api` prefix is embedded in the endpoint constant itself
+(see commit `f9219e0`); do not re-add it at the call site.
+
+### 4.3. Transport
+
+- REST via `libcpr`; WebSocket/real-time via `centrifugo-cpp`.
+- The CA bundle is **embedded** from `assets/certs/cacert.pem` via CMakeRC for reproducibility.
+  It is refreshed only by `./scripts/update-cacert.sh` during `make release` — never by hand.
+- Auth retries MUST use exponential backoff; TPM/ATCA transient errors MUST use randomized backoff.
+
+### 4.4. Secrets
+
+Provider private keys are encrypted at build time with `SCORBIT_SDK_ENCRYPT_SECRET` (see
+`cmake/encrypt.cmake` and `encrypt_tool/`). The secret is supplied by the CI environment. It MUST
+NOT appear in source, logs, test fixtures, or CMake cache files committed to the repo.
+
+---
+
+## 5. Testing & QA
+
+### 5.1. Framework
+
+- **Catch2 v3** (`v3.8.1`) with **trompeloeil v49** for mocking. Tests are registered with CTest
+  via `catch_discover_tests()`.
+- Google Test is NOT used. Any documentation claiming otherwise is stale.
+
+| Target | Scope |
+|--------|-------|
+| `tests/test_detail` | Internal implementation — compiles SDK sources directly with `SCORBIT_SDK_STATIC_DEFINE=1` |
+| `tests/test_interface` | Public C++ API against the built library |
+| `tests/test_interface_c` | Public C API (skipped on MSVC) |
+| `tests/test_python` | Python wrapper (`unittest`) — **not currently wired into CTest** |
+
+### 5.2. Rules
+
+- New behaviour in `source/` MUST have a `tests/test_detail` case. New public API MUST have a
+  `test_interface` (and `test_interface_c`) case.
+- `tests/test_detail/CMakeLists.txt` lists sources **explicitly**. A new test file is not compiled
+  until it is added there — verify your test actually ran, do not assume.
+- Test files MUST be named `test_<unit>.cpp` and mirror the unit under test.
+- Tests MUST NOT require network access, real hardware, or a provisioned TPM. Mock at the
+  `key_resolver` / `net_base` seam.
+- Run `ctest --test-dir build --output-on-failure` before claiming a change works. A passing
+  compile is not evidence.
+
+### 5.3. Known Test Gaps
+
+These are documented debt, not permission to add more:
+- `source/test_net.cpp` is commented out of `tests/test_detail/CMakeLists.txt` (lines ~107–109).
+- `tests/test_python/` is not registered with CTest and does not run in any pipeline.
+
+---
+
+## 6. Versioning, Packaging & Release
+
+### 6.1. Version Source of Truth
+
+`VERSION` at the repo root is the single source of truth. CMake reads it, the Python wheels read
+it, and both release workflows assert the git tag matches it exactly.
+
+### 6.2. Cutting a Release
+
+```bash
+# edit VERSION only; working tree otherwise clean
+make release      # creates chore/release_<version>, refreshes certs, commits the bump
+```
+
+`make release` refuses to run if `VERSION` is unmodified or if anything else is dirty. It creates:
+1. `chore: update certs` (only when `assets/certs/cacert.pem` changed)
+2. `chore(release): bump version to <version>`
+
+Then: open a PR → merge to `main` → tag `main` with the bare version (`2.0.4`, no `v` prefix) →
+push the tag.
+
+### 6.3. Artifact Matrix
+
+| Arch | ABI tag | Produced by |
+|------|---------|-------------|
+| `armhf` | `u12` | `make armhf` |
+| `arm64` | `u18` | `make arm64` |
+| `amd64` | `u18` | `make amd64` |
+| macOS arm64 | `macos` | `make macos` (development only, not released) |
+
+Each Linux build emits four artifacts: `scorbit_sdk-<ver>-<arch>_<abi>.{deb,tar.gz}` (runtime) and
+`scorbit_sdk-dev-<ver>-<arch>_<abi>.{deb,tar.gz}` (headers + CMake package files). Plus
+`encrypt_tool-*.tar.gz`, `scorbit-<ver>-py3-none-any.whl`, and `scorbit_py2-<ver>-py2-none-any.whl`.
+
+> **Doc drift:** `README.md` §"ABI Tag" documents `u12`, `u12dev`, and `u20`, but the release
+> pipeline ships `u12` and `u18`. Fix the README, not the pipeline, unless the ABI targets are
+> deliberately changing.
+
+### 6.4. Reproducible Builds
+
+Release builds are byte-reproducible and MUST stay that way:
+- `SOURCE_DATE_EPOCH` is derived from the last commit; `TZ=UTC`, `LC_ALL=C`, `LANG=C`, `umask 022`.
+- `-ffile-prefix-map` / `-fdebug-prefix-map` strip absolute paths.
+- `.deb` files are unpacked and rebuilt with `--root-owner-group`, a normalized `Installed-Size:`,
+  and uniform gzip compression (`scripts/build-core.sh`).
+- The CA bundle is a versioned source input, not a build-time download.
+
+Changes that introduce timestamps, absolute paths, hostnames, or network fetches into build output
+are FORBIDDEN.
+
+### 6.5. Install Layout
+
+Linux packages install under `/opt/scorbit`. The runtime DEB's maintainer scripts add
+`/etc/ld.so.conf.d/scorbit-sdk.conf`, run `ldconfig`, set `/opt/scorbit/lib` to mode `0777` so a
+non-root process can replace `.so` files during self-update, and install the RPI-RP2 `/etc/fstab`
+block via `/opt/scorbit/bin/add-rpi-rp2-fstab.sh`. Changing any of this affects field devices and
+requires explicit sign-off.
+
+---
+
+## 7. Git / PR — scorbit_sdk-specific rules
+
+> **Cross-stack Git/PR rules** live in canonical upstream:
+> [scorbit-io/eng_docs `_shared/AGENT_CONVENTIONS.md` §1–§3](https://github.com/scorbit-io/eng_docs/blob/main/governance/_shared/AGENT_CONVENTIONS.md).
+
+### 7.1. Branch Naming
+
+New branches MUST match:
+
+```
+^(feature|fix|chore|hotfix|refactor|perf)/(SB-\d+-)?[a-z0-9._-]+$
+```
+
+- A Linear ticket SHOULD be referenced: `feature/SB-3394-set-lan-ip`.
+- `improve/…` and `release/…` are **legacy** and MUST NOT be used for new branches — use `chore/`.
+- This repo has **no** pre-push hook enforcing the pattern (unlike `api`). Compliance is a review
+  responsibility.
+
+### 7.2. Commit Messages
+
+Conventional Commits, `<type>(<scope>): <subject>`, imperative mood, no trailing period.
+
+Allowed types: `feat`, `fix`, `chore`, `refactor`, `perf`, `docs`, `test`, `build`, `ci`.
+`improve` appears in history but is **deprecated** — map it to `feat`, `perf`, or `refactor`.
+
+Scopes in active use: `net`, `build`, `tpm`, `nfc`, `packaging`, `release`, `diag`, `python`,
+`api`, `provision`, `worker`, `fmt`, `tests`, `logger`, `cf`.
+
+Breaking ABI/API changes MUST use `!` (`feat!: API v2`) and MUST be called out in the PR body.
+
+### 7.3. PR Requirements
+
+A PR is not reviewable until all of the following hold:
+- It builds clean on at least one Linux arch (`make amd64` or an equivalent local Ninja build) with
+  `-Werror` in force.
+- `ctest --output-on-failure` passes.
+- Changed C/C++ files are `clang-format`-clean; changed CMake files are `gersemi`-clean.
+- New public API has **both** C++ and C surfaces, Python `ctypes` bindings, an example update, and
+  tests.
+- The PR body carries `FIXES: SB-XXXX` (or `Part of SB-XXXX`) on its own line when a Linear issue
+  exists.
+- **Because PR-gating CI is currently disabled (see §7.6), the author MUST paste the build and
+  `ctest` output into the PR description as evidence.**
+
+### 7.4. Files That MUST NOT Be Modified Without Explicit Request
+
+- `VERSION` — owned by the `make release` flow
+- `DOCKER_RELEASE` — pins the builder image tag
+- `assets/certs/cacert.pem` — refreshed only by `scripts/update-cacert.sh`
+- `assets/deb/`, `assets/scripts/` — maintainer scripts that run on customer devices
+- `.github/workflows/` — CI/CD pipelines
+- `cmake/` — packaging and dependency modules
+- `.clang-format`, `.gersemirc` — reformatting the tree is a separate, standalone PR
+
+### 7.5. Responding to PR Review Comments
+
+Every review comment — human or bot (Copilot review is enabled on this repo) — MUST be answered
+before the PR is considered done. Use the GitHub GraphQL API via `gh api graphql`; the REST reply
+endpoints return 404.
+
+```bash
+gh api graphql -f query='
+{
+  repository(owner: "scorbit-io", name: "scorbit_sdk") {
+    pullRequest(number: <PR_NUMBER>) {
+      reviewThreads(first: 20) {
+        nodes { id isResolved comments(first: 1) { nodes { body databaseId } } }
+      }
+    }
+  }
+}'
+```
+
+```bash
+gh api graphql -f query='
+mutation {
+  reply: addPullRequestReviewThreadReply(input: {
+    pullRequestReviewThreadId: "PRRT_...",
+    body: "Fixed in <commit_sha>."
+  }) { comment { id } }
+  resolve: resolveReviewThread(input: { threadId: "PRRT_..." }) { thread { isResolved } }
+}'
+```
+
+Rules: always state the action taken and the commit SHA; always resolve after replying; batch
+threads with aliases; **NEVER use backticks in the `body` field** — they break GraphQL parsing.
+
+### 7.6. CI Status — READ THIS
+
+As of this document's authoring, **five of seven GitHub Actions workflows are
+`disabled_manually`**: `Style`, `MacOS`, `Windows`, `Install`, and `Documentation`. Only the
+tag-triggered `Release Ubuntu` and `Release PyPI` workflows are active.
+
+Those five workflows are also **broken as written** — they run `cmake -Stest -Bbuild` against a
+`test/` directory that does not exist (the directory is `tests/`), and `style.yml` builds a
+`check-format` target that no build file defines. Re-enabling them without fixing those two
+problems will produce red builds, not green ones.
+
+**Consequence:** nothing verifies a pull request automatically. Local verification and pasted
+evidence (§7.3) are the only gate. Do not describe a change as "CI green" — there is no PR CI.
+
+---
+
+## 8. Issue Tracking — scorbit_sdk-specific rules
+
+> **Cross-stack Linear lifecycle** lives in canonical upstream:
+> [scorbit-io/eng_docs `_shared/AGENT_CONVENTIONS.md` §5](https://github.com/scorbit-io/eng_docs/blob/main/governance/_shared/AGENT_CONVENTIONS.md).
+> See also `SDLC.md` §8 for the state map.
+
+### 8.1. Linear
+
+**Linear is the only issue tracker for this repo.** Issues are `SB-XXXX` on team **Scorbit**. The
+native HTTP MCP server at `https://mcp.linear.app/mcp` is canonical. Priority values: `0`=None,
+`1`=Urgent, `2`=High, `3`=Normal, `4`=Low.
+
+### 8.2. Rules
+
+- Every non-trivial change SHOULD have a Linear issue; reference it in the branch name and in the
+  PR body as `FIXES: SB-XXXX` (or `Part of SB-XXXX`).
+- NEVER mark a Linear issue "Done" manually — `FIXES: SB-XXXX` plus merge handles it.
+- NEVER move an issue to "In Review" while the PR is still a draft.
+
+---
+
+## 9. Documentation & Licensing
+
+### 9.1. Doxygen
+
+Public headers MUST carry Doxygen comments (`/** … */`) for every exported type, function, and
+enumerator. `documentation/` builds the published reference; the `Documentation` workflow that
+published it is currently disabled.
+
+### 9.2. License Header
+
+Every source file MUST begin with the MIT header:
+
+```cpp
+/*
+ * Scorbit SDK
+ *
+ * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scorbit.io, All Rights Reserved
+ *
+ * MIT License
+ * ...
+ */
+```
+
+Two standing defects, both pre-existing on `main`:
+- **`scrobit.io` typo** (missing second `o`) appears in the header of ~146 files. New files MUST
+  use `scorbit.io`. A tree-wide fix belongs in its own `chore:` PR.
+- Missing headers entirely: `source/dflags.h`, `source/identifiers.h`,
+  `include/scorbit_sdk/event.h`.
+
+### 9.3. README
+
+`README.md` is customer-facing — it documents package names, ABI tags, and install paths that
+integrators depend on. Any change to packaging, install prefix, or ABI targets MUST update it in
+the same PR.
+
+---
+
+## 10. Dependencies
+
+Fetched via **CPM** (`cmake/CPM.cmake`), not `FetchContent`. Each has a dedicated
+`cmake/lib_<name>.cmake` module.
+
+| Dependency | Purpose |
+|------------|---------|
+| `fmtlib/fmt` | String formatting (also the URL templating engine) |
+| `libcpr/cpr` | HTTP client |
+| `nlohmann/json` | JSON parsing |
+| `centrifugo-cpp` | WebSocket real-time messaging |
+| `Boost` | `filesystem`, `thread`, `url` (compiled); `asio`, `uuid`, `dll`, `signals2`, `flyweight` (header-only) |
+| `OpenSSL::Crypto` | Cryptography (system `find_package`) |
+| `LibArchive` | Archive extraction for self-update |
+| `concurrentqueue` | Lock-free event queue |
+| `CMakeRC` | Embedding the CA bundle |
+| `Catch2` + `trompeloeil` | Testing (test targets only) |
+| `libs/logger`, `libs/tpm`, `libs/nfc`, `libs/utils` | In-repo sub-libraries |
+
+New dependencies MUST be discussed before adding — every one lands on constrained embedded targets
+and must cross-compile for armhf/arm64/amd64 under the pinned builder image.
+
+---
+
+*Cross-stack rules (branch naming, Conventional Commits, PR standards, Linear lifecycle,
+governance distribution) are in
+[scorbit-io/eng_docs `_shared/AGENT_CONVENTIONS.md`](https://github.com/scorbit-io/eng_docs/blob/main/governance/_shared/AGENT_CONVENTIONS.md).
+This file supersedes the stale `AGENT_CONVENTIONS.md` on the unmerged
+`feature/achievements-module` branch, which documents C++17, Google Test, FetchContent, and a
+`scripts/u20-build.sh` that no longer exists.*

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,130 @@
+# Claude Code Project Instructions — scorbit_sdk (C/C++/Python)
+
+> **Shared protocol:** the cross-stack workflow boilerplate (issue tracking, branch
+> workflow, session completion, bypass policy) follows canonical upstream:
+> [scorbit-io/eng_docs `_shared/CLAUDE.md`](https://github.com/scorbit-io/eng_docs/blob/main/governance/_shared/CLAUDE.md).
+> This file contains scorbit_sdk-specific overrides and additions only.
+
+## 1. Governance & Conventions
+
+Coding standards are in **AGENT_CONVENTIONS.md**. Delivery process is in **SDLC.md**.
+Read AGENT_CONVENTIONS.md §0 (environment) and §3 (dual API pattern) before touching any code.
+
+These three governance files (`CLAUDE.md`, `AGENT_CONVENTIONS.md`, `SDLC.md`) are tracked in this
+repo. They are modeled on the `api` repo's governance set; unlike `api`, this repo does **not** yet
+have `/sdlc:init` hooks or an eng_docs mirror check installed.
+
+## 2. What This Repo Is
+
+A **C++20 shared library** with a stable **C ABI** and pure-Python (`ctypes`) wrappers, shipped to
+pinball manufacturers as `.deb`/`.tar.gz` packages for armhf/arm64/amd64 and as PyPI wheels. It
+runs unattended on embedded devices in the field, talks to `api/v2` over REST and Centrifugo, and
+can self-update its own `.so`.
+
+Practical consequences for every change:
+- **The C ABI is a contract.** Breaking it strands deployed machines. See AGENT_CONVENTIONS.md §3.
+- **Builds must stay byte-reproducible.** No timestamps, absolute paths, or network fetches in
+  build output. See AGENT_CONVENTIONS.md §6.4.
+- **Failures must degrade, not crash.** The SDK is embedded in a host process it does not own.
+
+## 3. Development Environment
+
+Release builds run in Docker (`dilshodm/gcc-builder:$(cat DOCKER_RELEASE)`); day-to-day work uses a
+local Ninja build. See **AGENT_CONVENTIONS.md §0** for the full table.
+
+```bash
+cmake -B build -S . -DCMAKE_BUILD_TYPE=Debug -G Ninja
+cmake --build build -j
+ctest --test-dir build --output-on-failure
+```
+
+**Claude Code-specific rules:**
+- **Never build in-source.** CMake hard-fails; the correct pattern is always `-B build -S .`.
+- **Long builds:** run `cmake --build`, `make <arch>`, and `ctest` with `run_in_background: true`.
+  A cold CPM cache makes the first configure genuinely slow.
+- **Sequential Bash calls:** commands that may exit non-zero (`gh pr checks`, `gh run view`,
+  `ctest`) run sequentially, not in parallel.
+- **GitHub GraphQL:** never use backticks in the `body` field — they break GraphQL string parsing.
+  Never chain multiple `gh api graphql` calls with `&&`.
+
+## 4. Quality Gates (MANDATORY if code changed)
+
+```bash
+clang-format -i <changed .h/.cpp/.c files>     # pinned to clang-format 14.0.6
+./scripts/format-cmakelists.sh                  # if any CMakeLists.txt changed
+cmake --build build -j                          # MUST be clean; -Werror is in force
+ctest --test-dir build --output-on-failure      # MUST pass
+```
+
+There is **no coverage gate** here (unlike `api`'s 100% requirement), and — critically — **there is
+no PR-gating CI** (see §7). Local evidence is the only gate that exists. Paste the build and
+`ctest` output into the PR.
+
+## 5. Pre-Implementation Checklist
+
+Before writing ANY code, confirm (see AGENT_CONVENTIONS.md §1–§3):
+- [ ] Public API? → needs **both** `<feature>.h` (C++) and `<feature>_c.h` (C), in the same PR
+- [ ] New C entry point? → `wrappers/python/src/scorbit/_bindings.py` needs `argtypes`/`restype`
+- [ ] New URL, JSON key, or channel name? → `constexpr auto` in `source/identifiers.h`, never inline
+- [ ] New endpoint? → `api/v2/`, with the `/api` prefix already inside the constant
+- [ ] New event type? → the 7-step process in AGENT_CONVENTIONS.md §3.1, all four examples updated
+- [ ] New async/recurring work? → goes through `Worker`; new timers before the `Count` sentinel
+- [ ] New test file? → explicitly added to `tests/test_detail/CMakeLists.txt`, or it silently never runs
+- [ ] New source file? → MIT header spelled **`scorbit.io`** (the tree has a `scrobit.io` typo — do not copy it)
+- [ ] Touching `VERSION`, `DOCKER_RELEASE`, `assets/deb/`, `cmake/`, or `.github/`? → needs explicit request
+
+## 6. PR Review Comments
+
+Respond to every PR review comment — human or Copilot — before considering work done. Use the
+GraphQL mutation pattern in AGENT_CONVENTIONS.md §7.5. Always reference the fixing commit SHA and
+resolve the thread.
+
+## 7. Known Repo State — Do Not Rediscover This
+
+Verified against `main` at the time of writing. Treat as facts to work around, not as work to
+silently take on.
+
+| Area | State |
+|------|-------|
+| PR CI | **Absent.** `Style`, `MacOS`, `Windows`, `Install`, `Documentation` are all `disabled_manually`. Only tag-triggered `Release Ubuntu` / `Release PyPI` are active. |
+| Those workflows | **Broken as written.** They configure `cmake -Stest` (dir is `tests/`) and build a `check-format` target that does not exist. Re-enabling as-is yields red builds. |
+| `tests/test_python` | Not registered with CTest — never runs anywhere. |
+| `source/test_net.cpp` | Commented out of `tests/test_detail/CMakeLists.txt`. |
+| License headers | ~146 files carry the `scrobit.io` typo; `source/dflags.h`, `source/identifiers.h`, `include/scorbit_sdk/event.h` have no header at all. |
+| README ABI table | Documents `u12`/`u12dev`/`u20`; the pipeline actually ships `u12` and `u18`. |
+| `encrypt_tool/encrypt_tool` | A build artifact sitting untracked in the tree, not covered by `.gitignore`. Never `git add` it. |
+| `main` history | `origin/main` has been force-pushed at least once — PR #96 reports merged on GitHub, but its merge commit `a551c40` is absent from `origin/main`. Verify a merge actually landed before assuming it did. |
+| Stale governance | `feature/achievements-module` carries an older `AGENTS.md` + `AGENT_CONVENTIONS.md` claiming C++17, Google Test, FetchContent, and `scripts/u20-build.sh`. All four are wrong for `main`. This file set supersedes them. |
+
+## 8. Long-Lived Branches
+
+Several branches carry substantial unmerged work. Check before starting anything adjacent:
+
+| Branch | State |
+|--------|-------|
+| `feature/v2_achievements_module` | 6 commits incl. `feat!: API v2` — achievements REST + Centrifugo + local matching. Unmerged since Feb 2026. |
+| `fix/SB-4063-achievement-group-id-json-key` | PR #177, open. **Stacked on the unmerged achievements branch** — it cannot merge to `main` on its own. |
+| `feat/wifi_diagnostics` | 7 commits — standalone diagnostics library, WPA Supplicant D-Bus listener. Unmerged since May 2026. |
+| `feature/SB-3394-set-lan-ip` | PR #171, open since May 2026. Overlaps with the already-merged `feat(net): include local LAN IP in scorbitron object`. Verify it is not redundant. |
+
+Roughly a dozen other remote branches have had no commits since 2024–2025 and are candidates for
+deletion (see SDLC.md §9).
+
+## 9. Issue Tracking
+
+**Linear** (`SB-XXXX`, team Scorbit) is the only issue tracker for this repo. Reference the issue
+in the branch name and as `FIXES: SB-XXXX` in the PR body. Never mark a Linear issue Done
+manually — `FIXES: SB-XXXX` plus merge does it. See AGENT_CONVENTIONS.md §8.
+
+### SDLC Configuration
+
+- **Stack:** scorbit_sdk (C/C++/Python)
+- **Governance source:** [scorbit-io/eng_docs](https://github.com/scorbit-io/eng_docs/tree/main/governance) (canonical upstream)
+- **Governance files:** `CLAUDE.md`, `AGENT_CONVENTIONS.md`, `SDLC.md` (tracked in repo)
+- **Hooks:** none installed — this repo has no `.sdlc/git-hooks/`, no branch-name pre-push gate,
+  and no `SessionStart` mirror check. Conventions are review-enforced.
+- **Tracker:** Linear, team Scorbit (`SB-`)
+- **Branch pattern (review-enforced):** `^(feature|fix|chore|hotfix|refactor|perf)/(SB-\d+-)?[a-z0-9._-]+$`
+- **PR close keyword:** `FIXES:` · **Ref keyword:** `Part of`
+- **Merge strategy:** merge commit (repo history uses `Merge pull request #NNN from …`)
+- **Release tag format:** bare semver, no `v` prefix (`2.0.4`)

--- a/SDLC.md
+++ b/SDLC.md
@@ -1,0 +1,321 @@
+# SDLC Playbook — scorbit_sdk
+
+> **Source:** Derived from the Scorbit SDLC (`SDLC_Document-draft` v1.0 / `SDLC_Presentation.pdf`
+> v1.1) as adopted in [scorbit-io/api `SDLC.md`](https://github.com/scorbit-io/api/blob/main/SDLC.md),
+> adapted for a versioned, customer-distributed SDK.
+>
+> **Applies to:** the `scorbit_sdk` C/C++ library and its Python wrappers.
+>
+> **Key difference from the web/SaaS playbook:** the SDK is **not continuously deployed**. It is
+> cut as a versioned artifact, published to GitHub Releases and PyPI, and then *pulled* by
+> third-party manufacturers and by on-device self-update. Once a version is published it cannot be
+> recalled from devices already running it. Release discipline therefore replaces rollback as the
+> primary safety mechanism.
+>
+> The key words "MUST", "SHOULD", and "MAY" are interpreted per RFC 2119.
+
+---
+
+## 1. Work Hierarchy
+
+Identical to the company-wide hierarchy. Levels and owners do not change per stack.
+
+| Level | Name | Description | Typical Size | Owner |
+|-------|------|-------------|--------------|-------|
+| 1 | **Initiative** | Strategic theme or company-level goal. | Quarters to a year | PM + Leadership |
+| 2 | **Epic** | Significant capability delivering meaningful value. May be designated an MVP. | 2–6 weeks | PM + Tech Lead |
+| 3 | **Story** | Single, testable unit of functionality. Completable within one cycle. | 1–3 days | Engineer + PM |
+| 4 | **Task / Sub-task** | Specific technical action required to complete a story. | Hours | Engineer |
+
+**SDK-specific note:** most SDK work is developer-facing rather than end-user-facing. A story's
+"user" is frequently a *manufacturer integrator* or the *scorbitd/firmware team*, not a player.
+Write the user story from that consumer's perspective — "As an integrator, I want a C API for LAN
+IP so that I can report device network state without linking C++."
+
+---
+
+## 2. Planning Cadence
+
+The SDK follows the same quarterly / 2-week-cycle / daily rhythm as the rest of engineering.
+See the shared SDLC for the full cadence. SDK-specific additions:
+
+### 2.1. Quarterly
+
+- **ABI/API roadmap review is REQUIRED.** Any epic that changes `include/scorbit_sdk/*_c.h` MUST be
+  identified at quarterly planning, because it forces a major version bump and a coordinated
+  rollout with every consumer (scorbitd, vpinball, manufacturer integrations).
+- Toolchain and platform-support changes (new ABI tag, dropped architecture, compiler bump) MUST be
+  planned a quarter ahead — they invalidate every prebuilt package customers hold.
+
+### 2.2. Per Cycle
+
+Standard story readiness criteria apply. A story MUST additionally answer, before entering a cycle:
+
+1. Does it change the public API surface? If yes — C++ **and** C **and** Python binding scope is
+   included in the estimate.
+2. Does it require a firmware, `api`, or `scorbitd` change to land first? Dependencies MUST be
+   explicit.
+3. Does it affect packaging, install layout, or the self-update path? If yes, it needs a field-
+   impact note.
+
+### 2.3. Daily
+
+Standard. Blockers escalate to the Tech Lead same-day; no blocker sits more than 24 hours.
+
+---
+
+## 3. Story Standard
+
+The three story types (Feature, Bug, Spike) and their required fields are unchanged from the shared
+SDLC. SDK stories carry two extra required fields:
+
+- **API surface:** `none` · `C++ only` · `C++ and C` · `packaging/build only`
+- **Consumer impact:** which downstream repos or manufacturer integrations must change
+
+A story whose API surface is `C++ and C` is not Done until the Python `ctypes` bindings and all
+four examples are updated (AGENT_CONVENTIONS.md §3).
+
+---
+
+## 4. Acceptance Criteria Rules
+
+Standard rules apply: each criterion MUST be independently verifiable with a clear pass/fail
+outcome, and ACs MUST be written before estimation — "No AC = not ready."
+
+SDK-flavoured examples:
+
+| Context | Bad (vague) | Good (testable) |
+|---------|------------|-----------------|
+| C API | "The C API exposes LAN IP." | "`sb_config_set_lan_ip(config, ip)` accepts a NUL-terminated string; the value appears in the scorbitron object PATCH body; passing `NULL` omits the field rather than sending an empty string." |
+| Reliability | "Auth retries are better." | "After 3 consecutive 401s, retry intervals follow 1s/2s/4s/8s capped at 60s, verified by a `test_detail` case with a mocked clock." |
+| Packaging | "The deb installs correctly." | "`dpkg -i scorbit_sdk-<ver>-arm64_u18.deb` creates `/etc/ld.so.conf.d/scorbit-sdk.conf`, leaves `/opt/scorbit/lib` at mode 0777, and `ldconfig -p` lists `libscorbit_sdk.so.2`." |
+| Reproducibility | "The build is deterministic." | "Two `make amd64` runs from the same commit produce `.deb` files with identical SHA-256." |
+
+---
+
+## 5. Definition of Done
+
+### 5.1. Story-Level DoD
+
+A story is done when ALL of the following are true:
+
+- Code is written, reviewed, and merged to `main` via a pull request
+- At least one other engineer has reviewed and approved the PR
+- All acceptance criteria are met and confirmed by the author
+- The change builds clean with `-Werror` on at least one Linux target, and `ctest` passes
+- **Build and `ctest` output is pasted in the PR** — this repo has no PR-gating CI
+  (AGENT_CONVENTIONS.md §7.6), so evidence is manual
+- New behaviour has unit tests, explicitly added to the relevant `tests/*/CMakeLists.txt`
+- New public API has C++ + C surfaces, Python bindings, example updates, and Doxygen comments
+- Changed C/C++ files are `clang-format`-clean; changed CMake files are `gersemi`-clean
+- Any packaging, install-path, or README-visible change updates `README.md` in the same PR
+- The Linear issue is in the correct state
+
+### 5.2. Cycle-Level DoD
+
+Unchanged from the shared SDLC: carryover documented and re-estimated, Cycle Review demo held,
+Retrospective held with at least one logged improvement action.
+
+### 5.3. Release-Level DoD
+
+| Check | Required |
+|-------|----------|
+| All stories in scope meet Story DoD | REQUIRED |
+| `VERSION` bumped via `make release` (not by hand) | REQUIRED |
+| Semver correctness reviewed: ABI break → major; new API → minor; fix only → patch | REQUIRED |
+| CA bundle refreshed (`scripts/update-cacert.sh`, run automatically by `make release`) | REQUIRED |
+| `make all` succeeds — all three Linux arches + both Python wheels | REQUIRED |
+| Reproducibility spot-check: a repeat build of one arch yields identical artifact hashes | REQUIRED |
+| Full `ctest` run green on at least one arch | REQUIRED |
+| Install smoke test: `.deb` installs and a linked example runs on a real arm64 or armhf device | REQUIRED |
+| Self-update path exercised at least once per **minor** release | REQUIRED |
+| Python wheel smoke test: `pip install` + `import scorbit` against the matching native package | REQUIRED |
+| `README.md` package names, ABI tags, and install instructions match the artifacts produced | REQUIRED |
+| Release notes drafted on the GitHub release, with any ABI/API break called out first | REQUIRED |
+| Downstream consumers notified when the API surface changed (scorbitd, vpinball, integrators) | REQUIRED |
+
+**There is no rollback.** Once a release is published and a device self-updates, the only remedy is
+a forward fix in a new version. Treat the publish step as irreversible.
+
+---
+
+## 6. Release Pipeline
+
+### 6.1. Versioning
+
+Bare semver in the root `VERSION` file — no `v` prefix. Both release workflows assert the git tag
+equals `VERSION` exactly and fail the release if it does not.
+
+| Change | Bump |
+|--------|------|
+| Any change to `include/scorbit_sdk/*_c.h` that is not purely additive | **major** |
+| New public API, new event type, new config option | **minor** |
+| Bug fix, performance work, packaging fix, dependency bump | **patch** |
+
+### 6.2. Cutting a Release
+
+```bash
+# 1. On a clean tree, edit VERSION only
+$EDITOR VERSION
+
+# 2. Create the release branch + commits (refuses if the tree is otherwise dirty)
+make release
+#    -> branch chore/release_<version>
+#    -> commit "chore: update certs"            (only if cacert.pem changed)
+#    -> commit "chore(release): bump version to <version>"
+
+# 3. Open a PR, get review, merge to main
+
+# 4. Tag the merge commit on main and push
+git tag <version> && git push origin <version>
+```
+
+### 6.3. What CI Does From There
+
+| Stage | Workflow | Trigger | Result |
+|-------|----------|---------|--------|
+| Build | `Release Ubuntu` (`ubuntu.yml`) | tag matching `[0-9]*.[0-9]*.[0-9]*` | Verifies tag == `VERSION`, verifies `SCORBIT_SDK_ENCRYPT_SECRET` is present, sets `SOURCE_DATE_EPOCH`/`TZ`/`LC_ALL`/`LANG`, runs `make all`, uploads a **draft** GitHub release with all 15 expected artifacts (`fail_on_unmatched_files: true`) |
+| Publish | *manual* | Tech Lead | Review the draft release, write release notes, publish |
+| PyPI | `Release PyPI` (`release-pypi.yml`) | GitHub release `published` | Re-verifies tag == `VERSION`, downloads `*.whl` from the release, publishes to PyPI via trusted publishing |
+
+The draft-release gate is deliberate: it is the last point at which a bad build can be discarded
+without anything reaching customers. Do not automate past it.
+
+`Release PyPI` also accepts `workflow_dispatch` with an existing tag, for republishing wheels
+without re-cutting a release.
+
+### 6.4. Artifact Set (15 files per release)
+
+- `scorbit_sdk-<ver>-{amd64,arm64}_u18.{deb,tar.gz}` and `scorbit_sdk-<ver>-armhf_u12.{deb,tar.gz}`
+- `scorbit_sdk-dev-<ver>-…` — the same six, headers + CMake package files
+- `encrypt_tool-*.tar.gz`
+- `scorbit-<ver>-py3-none-any.whl`, `scorbit_py2-<ver>-py2-none-any.whl`
+
+Adding or renaming an artifact requires updating the `files:` list in `ubuntu.yml`, or the release
+job fails on unmatched files.
+
+### 6.5. Consumer Coordination
+
+The SDK is a dependency of `scorbitd`, `vpinball`, and third-party manufacturer firmware. A release
+that changes the API surface MUST:
+
+1. Note the affected consumers in the Linear epic before the cycle in which it ships
+2. Land consumer-side changes behind the new version, not simultaneously with it
+3. State the required SDK version in the consumer repo's dependency pin
+
+Firmware releases are managed by the firmware team and operate outside this SDLC. Where a firmware
+release depends on an SDK version, the PM coordinates the ordering; SDK releases MUST NOT be
+blocked on the firmware cycle.
+
+---
+
+## 7. Hotfix & Incident Response
+
+### 7.1. Incident Severity
+
+| Severity | Condition | Response |
+|----------|-----------|----------|
+| **P1 — Critical** | Crash or hang in deployed machines, data loss, security issue, self-update bricking devices, complete loss of connectivity to the platform | Acknowledge within 1 hour (business hours). Post in `#incidents` immediately. Tech Lead decides fix-forward scope. PM owns integrator communication. Blameless post-mortem within 48 hours. |
+| **P2 — Degraded** | A feature is broken but machines remain functional and connected | Acknowledge same business day. Triage within 24 hours. Normal cycle process applies. |
+
+### 7.2. Hotfix Rule
+
+A hotfix MAY only be declared for a confirmed P1. Declaration authority is the Tech Lead or senior
+leadership.
+
+**Qualifies as P1:** crash in the field · data loss · security issue · bricked self-update ·
+complete platform disconnection
+
+**Does NOT qualify:** slow operation · log noise · a broken example · anything that can wait for the
+normal cycle
+
+**Hotfix process:**
+
+1. Tech Lead declares the hotfix and the target version (always a **patch** bump)
+2. Branch `hotfix/SB-XXXX-slug` off `main`
+3. Fix implemented; reviewed by a single reviewer (relaxed from the normal peer-review requirement)
+4. `make release` on the hotfix branch → merge → tag → `Release Ubuntu` → publish
+5. **Install smoke test on real hardware is NOT relaxed** — a hotfix that bricks self-update is
+   worse than the original incident
+6. Post-mortem within 48 hours
+
+No exceptions to Conventional Commits or the `FIXES: SB-XXXX` requirement, hotfix or not.
+
+### 7.3. Field Remediation
+
+Because published versions cannot be recalled, a P1 caused by a released version requires all of:
+
+- A patch release with the fix, published to GitHub Releases and PyPI
+- Confirmation that self-update reaches affected devices, or an explicit manual-upgrade advisory
+- Notice to any manufacturer holding the bad version
+
+---
+
+## 8. Linear State Map
+
+Linear is the single source of truth for product work, and the only issue tracker for this repo.
+
+| Linear State | Meaning | Who Moves It |
+|-------------|---------|--------------|
+| **Backlog** | Created but not yet refined or estimated | PM or Tech Lead on creation |
+| **To-Do** | Refined, estimated, ACs written; eligible for cycle planning | PM + Tech Lead after refining |
+| **In Progress** | Actively being worked on; branch created | Engineer on start |
+| **In Review** | PR open (non-draft) and awaiting code review | Engineer on PR creation |
+| **UAT** | Merged; awaiting acceptance testing | Engineer when PR merged, if `sdlc:uat` labelled |
+| **Done** | Story-level DoD met | Auto via `FIXES: SB-XXXX`, or PM after UAT |
+| **Cancelled** | Deprioritized or no longer relevant; reason documented | PM |
+
+**Default merge behaviour:** `FIXES: SB-XXXX` in a merged PR auto-transitions the issue from
+In Review to Done.
+
+**SDK-specific:** a story that is merged to `main` but **not yet in a published release** is not
+delivered to anyone. For stories where an integrator is waiting on the released artifact, label the
+issue `sdlc:uat` before merge and hold it in UAT until the release carrying it is published.
+
+Do not move an issue to In Review while its PR is still a draft. Do not mark Done manually.
+
+---
+
+## 9. Branch Hygiene
+
+The SDK accumulates long-lived branches faster than the web stack because feature work often waits
+on firmware or manufacturer coordination. Standing rules:
+
+- A feature branch that has not been rebased on `main` in **30 days** MUST be either rebased, or
+  converted to a draft PR with an explicit blocker noted in the Linear issue.
+- **Stacked branches MUST be declared.** A PR whose base is another unmerged branch cannot land on
+  `main` and MUST say so in its description. (Current example: PR #177
+  `fix/SB-4063-achievement-group-id-json-key` is stacked on the unmerged
+  `feature/v2_achievements_module`.)
+- Merged branches SHOULD be deleted at merge time.
+- Branches with no commits in **6 months** SHOULD be deleted or archived as a tag. The repo
+  currently carries roughly a dozen such branches, the oldest dating to 2024.
+- Release branches (`chore/release_*`) MUST be deleted after the tag is pushed.
+
+Branch review is a standing Cycle Review agenda item.
+
+---
+
+## 10. Known Process Gaps
+
+Tracked here so they are addressed deliberately rather than rediscovered each cycle. Each SHOULD
+become a Linear issue.
+
+| Gap | Impact | Suggested Fix |
+|-----|--------|---------------|
+| Five of seven workflows are `disabled_manually` (`Style`, `MacOS`, `Windows`, `Install`, `Documentation`) | No automated verification of any pull request | Fix and re-enable — see next row |
+| Those workflows reference `cmake -Stest` (directory is `tests/`) and a `check-format` target that no build file defines | They would fail immediately if re-enabled | Repoint to `tests/`, add a real `check-format` target driving `clang-format --dry-run -Werror` + `gersemi --check` |
+| No branch-name or commit-message enforcement | `improve/`, `release/`, underscore, and ticket-less branch names have all accumulated | Install the `.sdlc/git-hooks/` set used by `api`, or a lightweight pre-push hook |
+| `tests/test_python` is not registered with CTest | The Python wrapper has zero automated coverage | Add a CTest entry, or a CI job running `python -m unittest` against a built `.so` |
+| `source/test_net.cpp` is commented out of the build | The network layer — the SDK's largest failure surface — is untested | Restore it behind a mocked `net_base` seam |
+| No release checklist artifact | §5.3 lives only in this document | Add a GitHub release PR template mirroring §5.3 |
+| No `CHANGELOG.md` | Release notes are ad-hoc per GitHub release | Generate from Conventional Commits at release time |
+| No `CONTRIBUTING.md`, `CODEOWNERS`, or PR template | External contributors have no stated process; reviewers are assigned ad-hoc | Add all three |
+| Governance not mirrored from eng_docs | These files can drift from the canonical cross-stack rules | Run `/sdlc:init` + `/sdlc:sync-mirror` once the eng_docs `scorbit_sdk/` governance directory exists |
+
+---
+
+*Cross-stack process (work hierarchy, planning cadence, story standard, Linear lifecycle) is
+canonical in [scorbit-io/eng_docs](https://github.com/scorbit-io/eng_docs/tree/main/governance).
+This file documents the SDK-specific release pipeline, DoD, and hotfix rules that differ from the
+continuously-deployed web/SaaS model.*


### PR DESCRIPTION
Adds the governance set this repo was missing: `CLAUDE.md`, `AGENT_CONVENTIONS.md`, and `SDLC.md`, plus a short `AGENTS.md` pointer so non-Claude agents land on the same rules.

Modeled on the `api` repo's governance set, but written against the verified state of `main` rather than copied — every technical claim was checked against the build system, CI, and git history.

## Why

An older `AGENTS.md` + `AGENT_CONVENTIONS.md` pair exists on the unmerged `feature/achievements-module` branch. Four of its core claims are now wrong: it documents **C++17** (main is C++20), **Google Test** (it's Catch2 v3.8.1 + trompeloeil), **FetchContent** (it's CPM), and `scripts/u20-build.sh` (deleted; now `linux-build.sh <arch>`). These files supersede it.

## What's in each

- **`AGENT_CONVENTIONS.md`** — RFC 2119 rules: build/ABI matrix, the mandatory dual C++/C API pattern (including the Python `ctypes` binding step the old doc omitted entirely), `identifiers.h` constant prefixes, the `Worker` concurrency rule, reproducible-build constraints, and the `/opt/scorbit` install contract.
- **`CLAUDE.md`** — operational: quality gates, pre-implementation checklist, a "known repo state" table, and an inventory of long-lived branches.
- **`SDLC.md`** — adapted rather than mirrored. The web/SaaS playbook assumes continuous deployment with rollback; a published SDK version can't be recalled once a device self-updates, so release-gate discipline replaces rollback as the primary safety mechanism. Adds ABI-break planning, branch hygiene, and a known-process-gaps table.

## Findings worth acting on separately

Documented here, not fixed in this PR:

1. **There is no PR-gating CI.** Five of seven workflows are `disabled_manually` (`Style`, `MacOS`, `Windows`, `Install`, `Documentation`); only the tag-triggered release workflows are active.
2. **Those workflows are also broken as written** — they run `cmake -Stest -Bbuild` against a `test/` directory that doesn't exist (it's `tests/`), and `style.yml` builds a `check-format` target no build file defines. Re-enabling them as-is produces red builds.
3. `tests/test_python/` is never registered with CTest — the Python wrapper has zero automated coverage.
4. `source/test_net.cpp` is commented out of `tests/test_detail/CMakeLists.txt` — the network layer is untested.
5. ~146 files carry a `scrobit.io` typo in the MIT header; `source/dflags.h`, `source/identifiers.h`, and `include/scorbit_sdk/event.h` have no header at all.
6. `README.md` documents ABI tags `u12`/`u12dev`/`u20`; the pipeline actually ships `u12` and `u18`.
7. `origin/main` has been force-pushed at least once — PR #96 reports merged, but its merge commit `a551c40` is absent from `origin/main`.

## Verification

Docs-only change; no build or test impact. Rendered and cross-checked: all internal section references resolve, and every command, CMake option, ABI tag, dependency, and artifact name was verified against the tree at `35a4539`.

Note: no `FIXES:` line — there's no Linear issue for this. Happy to file one and amend if you'd prefer it tracked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)