### PR TITLE
fix(build): register tests with CTest at project roots

### DIFF
--- a/all/CMakeLists.txt
+++ b/all/CMakeLists.txt
@@ -21,6 +21,10 @@ include(${MY_CMAKE_DIR}/tools.cmake)
 
 set(SCORBIT_LOGGER "callback" CACHE STRING "Logger backend to use (callback or spdlog)")
 
+# See the note in tests/CMakeLists.txt: needed here too, or `ctest` from this build root exits 0
+# without running anything.
+enable_testing()
+
 add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/../tests ${CMAKE_BINARY_DIR}/tests)
 add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/../documentation ${CMAKE_BINARY_DIR}/documentation)
 add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/../examples ${CMAKE_BINARY_DIR}/examples)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -11,6 +11,11 @@ cmake_minimum_required(VERSION 3.28)
 
 project(test)
 
+# Register this directory with CTest so a top-level CTestTestfile.cmake is generated and the
+# subdirectories' tests are reachable from the build root. Without it, `ctest` run from the build
+# root reports "No test configuration file found!" and exits 0 — a pass having run nothing.
+enable_testing()
+
 add_subdirectory(test_detail)
 add_subdirectory(test_interface)
 if(NOT MSVC)


### PR DESCRIPTION
## Context

These changes came out of getting the C++ test suite running locally on macOS — they're just what I
needed to make `ctest` behave. **If they don't make sense in the broader scheme, or there's a
preferred way to do this, that's completely fine** — happy to drop or rework. I'm raising it because
the failure mode is silent, not because I'm attached to this particular fix.

FIXES: SB-4279

## Problem

`ctest` run from the top of a build directory reports success while executing **zero** tests.

Neither `tests/CMakeLists.txt` nor `all/CMakeLists.txt` calls `enable_testing()`, so no top-level
`CTestTestfile.cmake` is generated. Each of the three test subdirectories gets its own, but nothing
links them to the project root:

```console
$ cmake -S all -B build/all -DCMAKE_BUILD_TYPE=Debug && cmake --build build/all -j8
$ cd build/all && ctest
*********************************
No test configuration file found!
*********************************
$ echo $?
0
```

The exit code is the part that matters — anything reading that as a pass gets a green light for zero
tests executed. Same result from an `-S tests` build tree.

## Change

`enable_testing()` at both project roots, above the `add_subdirectory` calls. Two lines plus
explanatory comments.

## Verification

macOS 15, cmake 4.3.2, AppleClang.

| `ctest` from build root | before | after |
|---|---|---|
| `-S all` | `No test configuration file found!`, exit 0, 0 tests | **189 passed, 0 failed** |
| `-S tests` | same | **189 passed, 0 failed** |

Top-level `CTestTestfile.cmake` is now generated in both layouts. Purely additive: anyone already
invoking ctest per-suite (`build/all/tests/test_detail`, etc.) sees no change.

## Deliberately not included

All found while investigating, left out to keep this reviewable. Happy to fold any in here or file
separately — your call:

1. **`-S tests` and `-S examples/*` can't configure standalone.** They reference `${MY_CMAKE_DIR}`,
   which only the root and `all/` projects define, so it expands to a literal `/CPM.cmake` and then
   `Unknown CMake command "CPMAddPackage"`. Workaround is `-DMY_CMAKE_DIR="$PWD/cmake"`. An
   `if(NOT DEFINED MY_CMAKE_DIR)` guard in `cmake/tools.cmake` (above the early return at line 9)
   would fix it and is a verified no-op for `-S all` and root builds, since both define the variable
   first. Left out because `-S all` is the supported entry point and needs no flags. Related:
   `cmake/tools.cmake:4-6` still sets an old `cmake_dir` name that nothing reads.

2. **`examples/c_example/CMakeLists.txt:23`** calls `CPMAddPackage` with no `CPM.cmake` include at
   all. It only works today because `all/`'s `tools.cmake` include has already defined `CPMAddPackage`
   globally by the time `examples/` is added.

3. **`-Stest` (singular) in four workflows** — `macos.yml:30`, `install.yml:36`, `style.yml:32`,
   `windows.yml:30`. The directory was renamed `test` → `tests` in df02d55 (2024-10-14) without
   updating them. Left out because all four workflows are `disabled_manually` with no run history, so
   the typo has no effect today, and re-enabling them is a larger decision than this PR — it would
   turn on a gate that's been off ~22 months, including on Windows where this suite has never run.

If those workflows are ever re-enabled, `ctest --no-tests=error` would make a recurrence of this bug
fail loudly rather than pass silently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
