### PR TITLE
feat(net): add UTM attribution to machine deep links

### DIFF
--- a/source/identifiers.h
+++ b/source/identifiers.h
@@ -40,6 +40,12 @@ constexpr auto URL_DIAGNOSTICS_ACK_PATH {"internal/api/diagnostics/ack/"};
 
 constexpr auto URL_V2_PROVISION {"api/v2/provision/"};
 
+constexpr auto PAIRING_DEEPLINK {"https://scorbit.link/"
+                                 "qrcode?$deeplink_path={manufacturer_prefix}"
+                                 "&machineid={scorbit_machine_id}&uuid={scorbitron_uuid}"
+                                 "&utm_medium=qr_code&utm_source=machine_pricing_card"
+                                 "&utm_campaign=machine_pairing"};
+
 constexpr auto URL_NFC_TAG {"https://scorbit.link/machines/{machine_uuid}?n={nonce}"
                             "&utm_medium=nfc&utm_source=machine_nfc_tag"
                             "&utm_campaign=anonymous_play_claim"};

--- a/source/identifiers.h
+++ b/source/identifiers.h
@@ -40,9 +40,12 @@ constexpr auto URL_DIAGNOSTICS_ACK_PATH {"internal/api/diagnostics/ack/"};
 
 constexpr auto URL_V2_PROVISION {"api/v2/provision/"};
 
-constexpr auto URL_NFC_TAG {"https://scorbit.link/machines/{machine_uuid}?n={nonce}"};
+constexpr auto URL_NFC_TAG {"https://scorbit.link/machines/{machine_uuid}?n={nonce}"
+                            "&utm_medium=nfc&utm_source=machine_nfc_tag"
+                            "&utm_campaign=anonymous_play_claim"};
 constexpr auto URL_CLAIM_DEEPLINK {
-        "https://scorbit.link/machines/{machine_uuid}/?score_id={score_id}"};
+        "https://scorbit.link/machines/{machine_uuid}/?score_id={score_id}"
+        "&utm_medium=machine&utm_source=score_claim&utm_campaign=anonymous_play_claim"};
 
 constexpr auto URL_SESSIONS_ID {"sessions"};
 

--- a/source/net.cpp
+++ b/source/net.cpp
@@ -66,7 +66,9 @@ constexpr auto SESSION_CSV_URL {"session_log/"};
 
 constexpr auto PAIRING_DEEPLINK {"https://scorbit.link/"
                                  "qrcode?$deeplink_path={manufacturer_prefix}"
-                                 "&machineid={scorbit_machine_id}&uuid={scorbitron_uuid}"};
+                                 "&machineid={scorbit_machine_id}&uuid={scorbitron_uuid}"
+                                 "&utm_medium=qr_code&utm_source=machine_pricing_card"
+                                 "&utm_campaign=machine_pairing"};
 
 constexpr auto NET_TIMEOUT = 14s;
 /// Connect-phase limit for large uploads/downloads (TLS + TCP); separate from transfer duration.

--- a/source/net.cpp
+++ b/source/net.cpp
@@ -64,11 +64,9 @@ namespace detail {
 
 constexpr auto SESSION_CSV_URL {"session_log/"};
 
-constexpr auto PAIRING_DEEPLINK {"https://scorbit.link/"
-                                 "qrcode?$deeplink_path={manufacturer_prefix}"
-                                 "&machineid={scorbit_machine_id}&uuid={scorbitron_uuid}"
-                                 "&utm_medium=qr_code&utm_source=machine_pricing_card"
-                                 "&utm_campaign=machine_pairing"};
+/// Upper bound for an NFC tag URI. ProbeNFC::SetUri() writes the length as a uint8_t
+/// (libs/nfc/include/nfc/Probe.h), so anything longer wraps and silently corrupts the tag.
+constexpr std::size_t MAX_NFC_TAG_URI_LENGTH = 255;
 
 constexpr auto NET_TIMEOUT = 14s;
 /// Connect-phase limit for large uploads/downloads (TLS + TCP); separate from transfer duration.
@@ -3269,6 +3267,14 @@ void Net::setNfcTag()
 {
     const auto tag = fmt::format(URL_NFC_TAG, fmt::arg("machine_uuid", m_machineInfo.machineUuid),
                                  fmt::arg("nonce", consumeNonce()));
+
+    // The probe stores the URI length in a single byte, so a longer URI is truncated on the
+    // wire with no error signal. Skip programming rather than write a corrupt tag.
+    if (tag.size() > MAX_NFC_TAG_URI_LENGTH) {
+        ERR("NFC tag URI is {} bytes, exceeds the {} byte limit; skipping: {}", tag.size(),
+            MAX_NFC_TAG_URI_LENGTH, tag);
+        return;
+    }
 
     const auto ok = std::invoke([this, &tag]() {
         std::scoped_lock lock {m_nfcMutex};

--- a/tests/test_detail/CMakeLists.txt
+++ b/tests/test_detail/CMakeLists.txt
@@ -113,6 +113,8 @@ target_sources(
         ../../source/http_session_pool.h
         ../../source/http_session_pool.cpp
         source/test_http_session_pool.cpp
+        ../../source/identifiers.h
+        source/test_identifiers.cpp
         ../../source/worker.cpp
         ../../source/worker.h
         ../../source/utils/thread_priority.h

--- a/tests/test_detail/source/test_identifiers.cpp
+++ b/tests/test_detail/source/test_identifiers.cpp
@@ -1,0 +1,97 @@
+/*
+ * Scorbit SDK
+ *
+ * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scorbit.io, All Rights Reserved
+ *
+ * MIT License
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ */
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <fmt/format.h>
+
+#include <cstddef>
+#include <string>
+
+#include "identifiers.h"
+
+using namespace scorbit::detail;
+
+namespace {
+
+// Longest realistic substitutions, used to size the NFC tag against the probe's limit.
+constexpr auto MACHINE_UUID = "3f2504e0-4f89-11d3-9a0c-0305e82c3301";
+
+/// Mirrors MAX_NFC_TAG_URI_LENGTH in net.cpp. ProbeNFC::SetUri() writes the URI length as a
+/// uint8_t, so a longer URI is silently truncated on the wire.
+constexpr std::size_t NFC_URI_LIMIT = 255;
+
+} // namespace
+
+TEST_CASE("PAIRING_DEEPLINK carries UTM attribution")
+{
+    const auto url = fmt::format(PAIRING_DEEPLINK, fmt::arg("manufacturer_prefix", "stern"),
+                                 fmt::arg("scorbit_machine_id", 4242),
+                                 fmt::arg("scorbitron_uuid", MACHINE_UUID));
+
+    CHECK(url
+          == "https://scorbit.link/qrcode?$deeplink_path=stern&machineid=4242"
+             "&uuid=3f2504e0-4f89-11d3-9a0c-0305e82c3301"
+             "&utm_medium=qr_code&utm_source=machine_pricing_card&utm_campaign=machine_pairing");
+}
+
+TEST_CASE("URL_NFC_TAG carries UTM attribution")
+{
+    const auto url = fmt::format(URL_NFC_TAG, fmt::arg("machine_uuid", MACHINE_UUID),
+                                 fmt::arg("nonce", "9f86d081884c7d65"));
+
+    CHECK(url
+          == "https://scorbit.link/machines/3f2504e0-4f89-11d3-9a0c-0305e82c3301"
+             "?n=9f86d081884c7d65"
+             "&utm_medium=nfc&utm_source=machine_nfc_tag&utm_campaign=anonymous_play_claim");
+}
+
+TEST_CASE("URL_NFC_TAG fits within the probe's single-byte URI length")
+{
+    // The nonce is server-issued, so this guards the headroom left for it rather than one
+    // specific value. A regression here means Net::setNfcTag() starts skipping tag writes.
+    const auto url =
+            fmt::format(URL_NFC_TAG, fmt::arg("machine_uuid", MACHINE_UUID), fmt::arg("nonce", ""));
+
+    CHECK(url.size() <= NFC_URI_LIMIT);
+    CHECK(NFC_URI_LIMIT - url.size() >= 64);
+}
+
+TEST_CASE("URL_CLAIM_DEEPLINK carries UTM attribution")
+{
+    const auto url = fmt::format(URL_CLAIM_DEEPLINK, fmt::arg(ARG_MACHINE_UUID, MACHINE_UUID),
+                                 fmt::arg(ARG_SCORE_ID, 201));
+
+    CHECK(url
+          == "https://scorbit.link/machines/3f2504e0-4f89-11d3-9a0c-0305e82c3301/?score_id=201"
+             "&utm_medium=machine&utm_source=score_claim&utm_campaign=anonymous_play_claim");
+}
+
+TEST_CASE("NFC and claim deep links share a campaign but differ by medium and source")
+{
+    // Both links exist to get an unclaimed slot claimed; utm_medium/utm_source separate them.
+    // Keeping the campaign identical is what makes them roll up as one flow in analytics.
+    const std::string campaign {"utm_campaign=anonymous_play_claim"};
+
+    const auto nfc = fmt::format(URL_NFC_TAG, fmt::arg("machine_uuid", MACHINE_UUID),
+                                 fmt::arg("nonce", "abc"));
+    const auto claim = fmt::format(URL_CLAIM_DEEPLINK, fmt::arg(ARG_MACHINE_UUID, MACHINE_UUID),
+                                   fmt::arg(ARG_SCORE_ID, 1));
+
+    CHECK(nfc.find(campaign) != std::string::npos);
+    CHECK(claim.find(campaign) != std::string::npos);
+
+    CHECK(nfc.find("utm_medium=nfc") != std::string::npos);
+    CHECK(claim.find("utm_medium=machine") != std::string::npos);
+
+    CHECK(nfc.find("utm_source=machine_nfc_tag") != std::string::npos);
+    CHECK(claim.find("utm_source=score_claim") != std::string::npos);
+}

--- a/tests/test_detail/source/test_player_profiles_manager.cpp
+++ b/tests/test_detail/source/test_player_profiles_manager.cpp
@@ -140,8 +140,9 @@ TEST_CASE("PlayerProfile 2 players with unclaimed slot")
     auto p2 = pm.profile(2);
     REQUIRE(p2.has_value());
     CHECK_FALSE(p2->hasInfo());
-    CHECK(p2->claimDeeplink ==
-          "https://scorbit.link/machines/test-machine-uuid-1234/?score_id=201");
+    CHECK(p2->claimDeeplink
+          == "https://scorbit.link/machines/test-machine-uuid-1234/?score_id=201"
+             "&utm_medium=machine&utm_source=score_claim&utm_campaign=anonymous_play_claim");
 
     auto result2 = pm.setProfiles(profiles2, TEST_MACHINE_UUID);
     REQUIRE(result2.has_value());


### PR DESCRIPTION
## Summary

The three `scorbit.link` URLs this SDK generates carried no UTM/attribution params, so traffic originating at a physical machine was invisible to analytics. This appends a UTM block to each template.

| Template | Location | `utm_medium` | `utm_source` | `utm_campaign` |
|---|---|---|---|---|
| `PAIRING_DEEPLINK` | `source/identifiers.h` | `qr_code` | `machine_pricing_card` | `machine_pairing` |
| `URL_NFC_TAG` | `source/identifiers.h` | `nfc` | `machine_nfc_tag` | `anonymous_play_claim` |
| `URL_CLAIM_DEEPLINK` | `source/identifiers.h` | `machine` | `score_claim` | `anonymous_play_claim` |

Nothing else changes: nonce and `score_id` semantics are untouched, and only query params are appended.

## Notes on the values

**`PAIRING_DEEPLINK`** targets the same endpoint as the server-side pricing-card QR generator, which is getting an identical UTM block in a companion change. The values are character-identical so a single logical QR flow does not report inconsistently depending on which generator produced the code. That companion change has not landed yet, so the two are briefly out of sync.

**`URL_NFC_TAG` and `URL_CLAIM_DEEPLINK` share `utm_campaign=anonymous_play_claim`.** Both exist to get an unclaimed player slot claimed; `utm_medium` and `utm_source` separate them. The NFC tag is explicitly *not* attributed to `machine_pairing` — tapping a pad today routes to an app-store install, or deep-links into the machine and claims the slot. It does not perform pairing.

**`URL_CLAIM_DEEPLINK` uses `utm_medium=machine`** rather than a display mechanism such as `qr_code`. The SDK hands manufacturers a raw string and has no QR-generation code of its own, so how it is surfaced is manufacturer-controlled and unconfirmed. `machine` asserts only what is actually true: the link came from physical machine hardware.

## Compatibility

All three link shapes already tolerate unknown query params: the QR path key-matches and ignores unrelated params, and the NFC and claim paths read `{machine_uuid}` from the URL path plus named query keys, independent of what else is present.

The NFC tag has a hard length ceiling — `SetUri()` in `libs/nfc/include/nfc/Probe.h` stores the URI length in a single byte, so a URI at or past 256 characters wraps and programs a corrupt tag with no error signal. The UTM block adds 71 characters. Measured with a 36-character machine UUID and a 16-character nonce, the rendered tag is **161 of 255** characters, leaving 94 characters of headroom.

Because the nonce is server-issued, that headroom is not guaranteed, so `Net::setNfcTag()` now checks the formatted URI against a 255-byte limit and logs and skips rather than programming a tag that cannot be resolved. A test pins the remaining headroom at 64 bytes or more so a future template change fails the suite instead of the field.

## Verification

Local `-Werror` Ninja build, macOS arm64.

Build:

```
$ cmake --build build -j
[157/157] Creating library symlink libscorbit_sdk.2.dylib libscorbit_sdk.dylib
[exited with code 0]

$ cmake --build build-all -j
[324/324] Linking CXX executable tests/test_interface/scorbit_sdk_tests
[exited with code 0]
```

Clean. The only warnings emitted are pre-existing ones inside the third-party `cryptoauth` dependency.

Tests:

```
$ ctest --test-dir build-all/tests/test_detail --output-on-failure
100% tests passed, 0 tests failed out of 186

Total Test time (real) =  21.29 sec
```

`tests/test_detail/source/test_player_profiles_manager.cpp` is updated for the new claim URL. Catch2 expansion of the updated assertion, showing real `fmt::format` output from the production path:

```
CHECK( p2->claimDeeplink == "https://scorbit.link/machines/test-machine-uuid-1234/?score_id=201"
                            "&utm_medium=machine&utm_source=score_claim&utm_campaign=anonymous_play_claim" )
with expansion:
  "https://scorbit.link/machines/test-machine-uuid-1234/?score_id=201&
  utm_medium=machine&utm_source=score_claim&utm_campaign=anonymous_play_claim"
  ==
  "https://scorbit.link/machines/test-machine-uuid-1234/?score_id=201&
  utm_medium=machine&utm_source=score_claim&utm_campaign=anonymous_play_claim"
```

`tests/test_detail/source/test_identifiers.cpp` is new and covers all three templates: exact formatted output for each, the NFC length bound, and a case pinning the shared `utm_campaign` between the NFC and claim links while asserting their medium and source stay distinct. Rendered output:

```
PAIRING  (185) https://scorbit.link/qrcode?$deeplink_path=stern&machineid=4242&uuid=3f2504e0-4f89-11d3-9a0c-0305e82c3301&utm_medium=qr_code&utm_source=machine_pricing_card&utm_campaign=machine_pairing
NFC      (161) https://scorbit.link/machines/3f2504e0-4f89-11d3-9a0c-0305e82c3301?n=9f86d081884c7d65&utm_medium=nfc&utm_source=machine_nfc_tag&utm_campaign=anonymous_play_claim
CLAIM    (156) https://scorbit.link/machines/3f2504e0-4f89-11d3-9a0c-0305e82c3301/?score_id=201&utm_medium=machine&utm_source=score_claim&utm_campaign=anonymous_play_claim
```

`PAIRING_DEEPLINK` moved from `source/net.cpp` to `source/identifiers.h` as part of adding that coverage — `net.cpp` is not part of the `test_detail` target, so the template had no reachable test seam where it was. `net.cpp` already includes `identifiers.h`; the call site is unchanged.

Formatting: `clang-format` 14.0.6 clean on all changed C++ files, `gersemi` clean on `tests/test_detail/CMakeLists.txt`.

Examples: all four reference programs (`c`, `cpp`, `python`, `python27`) consume `claimDeeplink` as a pass-through string and print it, so no example changes are needed. They build clean as part of the superproject above.

FIXES: SB-4246
