### PR TITLE
chore: fix scrobit.io -> scorbit.io domain typo

### DIFF
--- a/all/CMakeLists.txt
+++ b/all/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Scorbit SDK
 #
-# (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scrobit.io, All Rights Reserved
+# (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scorbit.io, All Rights Reserved
 #
 # MIT License
 #

--- a/cmake/ArchDetect.cmake
+++ b/cmake/ArchDetect.cmake
@@ -1,6 +1,6 @@
 # Scorbit SDK
 #
-# (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scrobit.io, All Rights Reserved
+# (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scorbit.io, All Rights Reserved
 #
 # MIT License
 #

--- a/cmake/encrypt.cmake
+++ b/cmake/encrypt.cmake
@@ -1,6 +1,6 @@
 # Scorbit SDK
 #
-# (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scrobit.io, All Rights Reserved
+# (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scorbit.io, All Rights Reserved
 #
 # MIT License
 #

--- a/cmake/lib_boost.cmake
+++ b/cmake/lib_boost.cmake
@@ -1,4 +1,4 @@
-# (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scrobit.io, All Rights Reserved
+# (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scorbit.io, All Rights Reserved
 #
 # MIT License
 #

--- a/docker/ubuntu_builder_12.04/Dockerfile
+++ b/docker/ubuntu_builder_12.04/Dockerfile
@@ -1,6 +1,6 @@
 # Scorbit SDK
 #
-# (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scrobit.io, All Rights Reserved
+# (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scorbit.io, All Rights Reserved
 #
 # MIT License
 #

--- a/docker/ubuntu_builder_12.04/docker-build.sh
+++ b/docker/ubuntu_builder_12.04/docker-build.sh
@@ -2,7 +2,7 @@
 
 # Scorbit SDK
 #
-# (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scrobit.io, All Rights Reserved
+# (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scorbit.io, All Rights Reserved
 #
 # MIT License
 #

--- a/docker/ubuntu_builder_20.04/Dockerfile
+++ b/docker/ubuntu_builder_20.04/Dockerfile
@@ -1,6 +1,6 @@
 # Scorbit SDK
 #
-# (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scrobit.io, All Rights Reserved
+# (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scorbit.io, All Rights Reserved
 #
 # MIT License
 #

--- a/docker/ubuntu_builder_20.04/docker-build.sh
+++ b/docker/ubuntu_builder_20.04/docker-build.sh
@@ -2,7 +2,7 @@
 
 # Scorbit SDK
 #
-# (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scrobit.io, All Rights Reserved
+# (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scorbit.io, All Rights Reserved
 #
 # MIT License
 #

--- a/documentation/CMakeLists.txt
+++ b/documentation/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Scorbit SDK
 #
-# (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scrobit.io, All Rights Reserved
+# (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scorbit.io, All Rights Reserved
 #
 # MIT License
 #

--- a/documentation/Doxyfile
+++ b/documentation/Doxyfile
@@ -1,6 +1,6 @@
 # Scorbit SDK
 #
-# (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scrobit.io, All Rights Reserved
+# (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scorbit.io, All Rights Reserved
 #
 # MIT License
 #

--- a/documentation/conf.py
+++ b/documentation/conf.py
@@ -1,6 +1,6 @@
 # Scorbit SDK
 #
-# (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scrobit.io, All Rights Reserved
+# (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scorbit.io, All Rights Reserved
 #
 # MIT License
 #

--- a/encrypt_tool/CMakeLists.txt
+++ b/encrypt_tool/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Scorbit SDK
 #
-# (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scrobit.io, All Rights Reserved
+# (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scorbit.io, All Rights Reserved
 #
 # MIT License
 #

--- a/encrypt_tool/source/main.cpp
+++ b/encrypt_tool/source/main.cpp
@@ -1,7 +1,7 @@
 /*
  * Scorbit SDK
  *
- * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scrobit.io, All Rights Reserved
+ * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scorbit.io, All Rights Reserved
  *
  * MIT License
  *

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Scorbit SDK
 #
-# (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scrobit.io, All Rights Reserved
+# (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scorbit.io, All Rights Reserved
 #
 # MIT License
 #

--- a/examples/c_example/CMakeLists.txt
+++ b/examples/c_example/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Scorbit SDK
 #
-# (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scrobit.io, All Rights Reserved
+# (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scorbit.io, All Rights Reserved
 #
 # MIT License
 #

--- a/examples/c_example/Makefile
+++ b/examples/c_example/Makefile
@@ -1,6 +1,6 @@
 # Scorbit SDK
 #
-# (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scrobit.io, All Rights Reserved
+# (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scorbit.io, All Rights Reserved
 #
 # MIT License
 #

--- a/examples/c_example/main.c
+++ b/examples/c_example/main.c
@@ -1,7 +1,7 @@
 /*
  * Scorbit SDK
  *
- * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scrobit.io, All Rights Reserved
+ * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scorbit.io, All Rights Reserved
  *
  * MIT License
  *

--- a/examples/cpp_example/CMakeLists.txt
+++ b/examples/cpp_example/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Scorbit SDK
 #
-# (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scrobit.io, All Rights Reserved
+# (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scorbit.io, All Rights Reserved
 #
 # MIT License
 #

--- a/examples/cpp_example/main.cpp
+++ b/examples/cpp_example/main.cpp
@@ -1,7 +1,7 @@
 /*
  * Scorbit SDK
  *
- * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scrobit.io, All Rights Reserved
+ * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scorbit.io, All Rights Reserved
  *
  * MIT License
  *

--- a/include/scorbit_sdk/common_types_c.h
+++ b/include/scorbit_sdk/common_types_c.h
@@ -1,7 +1,7 @@
 /*
  * Scorbit SDK
  *
- * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scrobit.io, All Rights Reserved
+ * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scorbit.io, All Rights Reserved
  *
  * MIT License
  *

--- a/include/scorbit_sdk/config.h
+++ b/include/scorbit_sdk/config.h
@@ -1,7 +1,7 @@
 /*
  * Scorbit SDK
  *
- * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scrobit.io, All Rights Reserved
+ * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scorbit.io, All Rights Reserved
  *
  * MIT License
  *

--- a/include/scorbit_sdk/config_c.h
+++ b/include/scorbit_sdk/config_c.h
@@ -1,7 +1,7 @@
 /*
  * Scorbit SDK
  *
- * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scrobit.io, All Rights Reserved
+ * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scorbit.io, All Rights Reserved
  *
  * MIT License
  *

--- a/include/scorbit_sdk/event_helpers_c.h
+++ b/include/scorbit_sdk/event_helpers_c.h
@@ -1,7 +1,7 @@
 /*
  * Scorbit SDK
  *
- * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scrobit.io, All Rights Reserved
+ * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scorbit.io, All Rights Reserved
  *
  * MIT License
  *

--- a/include/scorbit_sdk/event_types.h
+++ b/include/scorbit_sdk/event_types.h
@@ -1,7 +1,7 @@
 /*
  * Scorbit SDK
  *
- * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scrobit.io, All Rights Reserved
+ * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scorbit.io, All Rights Reserved
  *
  * MIT License
  *

--- a/include/scorbit_sdk/event_types_c.h
+++ b/include/scorbit_sdk/event_types_c.h
@@ -1,7 +1,7 @@
 /*
  * Scorbit SDK
  *
- * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scrobit.io, All Rights Reserved
+ * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scorbit.io, All Rights Reserved
  *
  * MIT License
  *

--- a/include/scorbit_sdk/game_state.h
+++ b/include/scorbit_sdk/game_state.h
@@ -1,7 +1,7 @@
 /*
  * Scorbit SDK
  *
- * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scrobit.io, All Rights Reserved
+ * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scorbit.io, All Rights Reserved
  *
  * MIT License
  *

--- a/include/scorbit_sdk/game_state_c.h
+++ b/include/scorbit_sdk/game_state_c.h
@@ -1,7 +1,7 @@
 /*
  * Scorbit SDK
  *
- * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scrobit.io, All Rights Reserved
+ * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scorbit.io, All Rights Reserved
  *
  * MIT License
  *

--- a/include/scorbit_sdk/game_state_factory.h
+++ b/include/scorbit_sdk/game_state_factory.h
@@ -1,7 +1,7 @@
 /*
  * Scorbit SDK
  *
- * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scrobit.io, All Rights Reserved
+ * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scorbit.io, All Rights Reserved
  *
  * MIT License
  *

--- a/include/scorbit_sdk/leaderboard.h
+++ b/include/scorbit_sdk/leaderboard.h
@@ -1,7 +1,7 @@
 /*
  * Scorbit SDK
  *
- * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scrobit.io, All Rights Reserved
+ * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scorbit.io, All Rights Reserved
  *
  * MIT License
  *

--- a/include/scorbit_sdk/leaderboard_c.h
+++ b/include/scorbit_sdk/leaderboard_c.h
@@ -1,7 +1,7 @@
 /*
  * Scorbit SDK
  *
- * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scrobit.io, All Rights Reserved
+ * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scorbit.io, All Rights Reserved
  *
  * MIT License
  *

--- a/include/scorbit_sdk/log.h
+++ b/include/scorbit_sdk/log.h
@@ -1,7 +1,7 @@
 /*
  * Scorbit SDK
  *
- * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scrobit.io, All Rights Reserved
+ * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scorbit.io, All Rights Reserved
  *
  * MIT License
  *

--- a/include/scorbit_sdk/log_c.h
+++ b/include/scorbit_sdk/log_c.h
@@ -1,7 +1,7 @@
 /*
  * Scorbit SDK
  *
- * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scrobit.io, All Rights Reserved
+ * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scorbit.io, All Rights Reserved
  *
  * MIT License
  *

--- a/include/scorbit_sdk/log_types.h
+++ b/include/scorbit_sdk/log_types.h
@@ -1,7 +1,7 @@
 /*
  * Scorbit SDK
  *
- * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scrobit.io, All Rights Reserved
+ * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scorbit.io, All Rights Reserved
  *
  * MIT License
  *

--- a/include/scorbit_sdk/log_types_c.h
+++ b/include/scorbit_sdk/log_types_c.h
@@ -1,7 +1,7 @@
 /*
  * Scorbit SDK
  *
- * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scrobit.io, All Rights Reserved
+ * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scorbit.io, All Rights Reserved
  *
  * MIT License
  *

--- a/include/scorbit_sdk/net_types.h
+++ b/include/scorbit_sdk/net_types.h
@@ -1,7 +1,7 @@
 /*
  * Scorbit SDK
  *
- * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scrobit.io, All Rights Reserved
+ * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scorbit.io, All Rights Reserved
  *
  * MIT License
  *

--- a/include/scorbit_sdk/net_types_c.h
+++ b/include/scorbit_sdk/net_types_c.h
@@ -1,7 +1,7 @@
 /*
  * Scorbit SDK
  *
- * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scrobit.io, All Rights Reserved
+ * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scorbit.io, All Rights Reserved
  *
  * MIT License
  *

--- a/include/scorbit_sdk/player_info.h
+++ b/include/scorbit_sdk/player_info.h
@@ -1,7 +1,7 @@
 /*
  * Scorbit SDK
  *
- * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scrobit.io, All Rights Reserved
+ * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scorbit.io, All Rights Reserved
  *
  * MIT License
  *

--- a/include/scorbit_sdk/pricing_info.h
+++ b/include/scorbit_sdk/pricing_info.h
@@ -1,7 +1,7 @@
 /*
  * Scorbit SDK
  *
- * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scrobit.io, All Rights Reserved
+ * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scorbit.io, All Rights Reserved
  *
  * MIT License
  *

--- a/include/scorbit_sdk/scorbit_sdk.h
+++ b/include/scorbit_sdk/scorbit_sdk.h
@@ -1,7 +1,7 @@
 /*
  * Scorbit SDK
  *
- * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scrobit.io, All Rights Reserved
+ * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scorbit.io, All Rights Reserved
  *
  * MIT License
  *

--- a/include/scorbit_sdk/scorbit_sdk_c.h
+++ b/include/scorbit_sdk/scorbit_sdk_c.h
@@ -1,7 +1,7 @@
 /*
  * Scorbit SDK
  *
- * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scrobit.io, All Rights Reserved
+ * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scorbit.io, All Rights Reserved
  *
  * MIT License
  *

--- a/libs/nfc/include/nfc/ListUsbDevices.h
+++ b/libs/nfc/include/nfc/ListUsbDevices.h
@@ -1,7 +1,7 @@
 /*
  * scorbitd
  *
- * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scrobit.io, All Rights Reserved
+ * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scorbit.io, All Rights Reserved
  *
  * Proprietary License
  */

--- a/libs/nfc/source/list_usb_devices.cpp
+++ b/libs/nfc/source/list_usb_devices.cpp
@@ -1,7 +1,7 @@
 /*
  * scorbitd
  *
- * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scrobit.io, All Rights Reserved
+ * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scorbit.io, All Rights Reserved
  *
  * Proprietary License
  */

--- a/libs/nfc/source/list_usb_devices.h
+++ b/libs/nfc/source/list_usb_devices.h
@@ -1,7 +1,7 @@
 /*
  * scorbitd
  *
- * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scrobit.io, All Rights Reserved
+ * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scorbit.io, All Rights Reserved
  *
  * Proprietary License
  */

--- a/libs/tpm/include/tpm/crypto_helpers.h
+++ b/libs/tpm/include/tpm/crypto_helpers.h
@@ -1,7 +1,7 @@
 /*
  * Scorbit SDK
  *
- * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scrobit.io, All Rights Reserved
+ * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scorbit.io, All Rights Reserved
  *
  * MIT License
  *

--- a/libs/tpm/source/crypto_constants.h
+++ b/libs/tpm/source/crypto_constants.h
@@ -1,7 +1,7 @@
 /*
  * scorbitd
  *
- * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scrobit.io, All Rights Reserved
+ * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scorbit.io, All Rights Reserved
  *
  * Proprietary License
  */

--- a/libs/tpm/source/crypto_helpers.cpp
+++ b/libs/tpm/source/crypto_helpers.cpp
@@ -1,7 +1,7 @@
 /*
  * scorbitd - Refactored Implementation
  *
- * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scrobit.io, All Rights Reserved
+ * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scorbit.io, All Rights Reserved
  *
  * Proprietary License
  */

--- a/libs/tpm/source/crypto_utils.cpp
+++ b/libs/tpm/source/crypto_utils.cpp
@@ -1,7 +1,7 @@
 /*
  * scorbitd
  *
- * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scrobit.io, All Rights Reserved
+ * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scorbit.io, All Rights Reserved
  *
  * Proprietary License
  */

--- a/libs/tpm/source/crypto_utils.h
+++ b/libs/tpm/source/crypto_utils.h
@@ -1,7 +1,7 @@
 /*
  * scorbitd
  *
- * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scrobit.io, All Rights Reserved
+ * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scorbit.io, All Rights Reserved
  *
  * Proprietary License
  */

--- a/libs/utils/include/utils/bytearray.h
+++ b/libs/utils/include/utils/bytearray.h
@@ -1,7 +1,7 @@
 /*
  * Scorbit SDK
  *
- * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scrobit.io, All Rights Reserved
+ * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scorbit.io, All Rights Reserved
  *
  * MIT License
  *

--- a/libs/utils/include/utils/commandrunner.h
+++ b/libs/utils/include/utils/commandrunner.h
@@ -1,7 +1,7 @@
 /*
  * scorbitd
  *
- * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scrobit.io, All Rights Reserved
+ * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scorbit.io, All Rights Reserved
  *
  * Proprietary License
  */

--- a/libs/utils/include/utils/fs_read_write.h
+++ b/libs/utils/include/utils/fs_read_write.h
@@ -1,7 +1,7 @@
 /*
  * Scorbit SDK
  *
- * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scrobit.io, All Rights Reserved
+ * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scorbit.io, All Rights Reserved
  *
  * MIT License
  *

--- a/libs/utils/include/utils/utils.h
+++ b/libs/utils/include/utils/utils.h
@@ -1,7 +1,7 @@
 /*
  * scorbitd
  *
- * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scrobit.io, All Rights Reserved
+ * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scorbit.io, All Rights Reserved
  *
  * Proprietary License
  */

--- a/libs/utils/source/bytearray.cpp
+++ b/libs/utils/source/bytearray.cpp
@@ -1,7 +1,7 @@
 /*
  * Scorbit SDK
  *
- * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scrobit.io, All Rights Reserved
+ * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scorbit.io, All Rights Reserved
  *
  * MIT License
  *

--- a/libs/utils/source/commandrunner.cpp
+++ b/libs/utils/source/commandrunner.cpp
@@ -1,7 +1,7 @@
 /*
  * scorbitd
  *
- * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scrobit.io, All Rights Reserved
+ * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scorbit.io, All Rights Reserved
  *
  * Proprietary License
  */

--- a/libs/utils/source/fs_read_write.cpp
+++ b/libs/utils/source/fs_read_write.cpp
@@ -1,7 +1,7 @@
 /*
  * Scorbit SDK
  *
- * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scrobit.io, All Rights Reserved
+ * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scorbit.io, All Rights Reserved
  *
  * MIT License
  *

--- a/libs/utils/source/utils.cpp
+++ b/libs/utils/source/utils.cpp
@@ -1,7 +1,7 @@
 /*
  * scorbitd
  *
- * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scrobit.io, All Rights Reserved
+ * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scorbit.io, All Rights Reserved
  *
  * Proprietary License
  */

--- a/scripts/format-cmakelists.sh
+++ b/scripts/format-cmakelists.sh
@@ -2,7 +2,7 @@
 
 # Scorbit SDK
 #
-# (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scrobit.io, All Rights Reserved
+# (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scorbit.io, All Rights Reserved
 #
 # MIT License
 #

--- a/scripts/macos-build.sh
+++ b/scripts/macos-build.sh
@@ -2,7 +2,7 @@
 
 # Scorbit SDK
 #
-# (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scrobit.io, All Rights Reserved
+# (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scorbit.io, All Rights Reserved
 #
 # MIT License
 #

--- a/source/config_c.cpp
+++ b/source/config_c.cpp
@@ -1,7 +1,7 @@
 /*
  * Scorbit SDK
  *
- * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scrobit.io, All Rights Reserved
+ * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scorbit.io, All Rights Reserved
  *
  * MIT License
  *

--- a/source/device_info.h
+++ b/source/device_info.h
@@ -1,7 +1,7 @@
 /*
  * Scorbit SDK
  *
- * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scrobit.io, All Rights Reserved
+ * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scorbit.io, All Rights Reserved
  *
  * MIT License
  *

--- a/source/event_classes.h
+++ b/source/event_classes.h
@@ -1,7 +1,7 @@
 /*
  * Scorbit SDK
  *
- * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scrobit.io, All Rights Reserved
+ * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scorbit.io, All Rights Reserved
  *
  * MIT License
  *

--- a/source/event_helpers_c.cpp
+++ b/source/event_helpers_c.cpp
@@ -1,7 +1,7 @@
 /*
  * Scorbit SDK
  *
- * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scrobit.io, All Rights Reserved
+ * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scorbit.io, All Rights Reserved
  *
  * MIT License
  *

--- a/source/event_manager.h
+++ b/source/event_manager.h
@@ -1,7 +1,7 @@
 /*
  * Scorbit SDK
  *
- * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scrobit.io, All Rights Reserved
+ * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scorbit.io, All Rights Reserved
  *
  * MIT License
  *

--- a/source/event_queue.h
+++ b/source/event_queue.h
@@ -1,7 +1,7 @@
 /*
  * Scorbit SDK
  *
- * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scrobit.io, All Rights Reserved
+ * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scorbit.io, All Rights Reserved
  *
  * MIT License
  *

--- a/source/fmt_formatters.h
+++ b/source/fmt_formatters.h
@@ -1,7 +1,7 @@
 /*
  * Scorbit SDK
  *
- * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scrobit.io, All Rights Reserved
+ * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scorbit.io, All Rights Reserved
  *
  * MIT License
  *

--- a/source/game_data.h
+++ b/source/game_data.h
@@ -1,7 +1,7 @@
 /*
  * Scorbit SDK
  *
- * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scrobit.io, All Rights Reserved
+ * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scorbit.io, All Rights Reserved
  *
  * MIT License
  *

--- a/source/game_state_c.cpp
+++ b/source/game_state_c.cpp
@@ -1,7 +1,7 @@
 /*
  * Scorbit SDK
  *
- * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scrobit.io, All Rights Reserved
+ * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scorbit.io, All Rights Reserved
  *
  * MIT License
  *

--- a/source/game_state_impl.cpp
+++ b/source/game_state_impl.cpp
@@ -1,7 +1,7 @@
 /*
  * Scorbit SDK
  *
- * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scrobit.io, All Rights Reserved
+ * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scorbit.io, All Rights Reserved
  *
  * MIT License
  *

--- a/source/game_state_impl.h
+++ b/source/game_state_impl.h
@@ -1,7 +1,7 @@
 /*
  * Scorbit SDK
  *
- * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scrobit.io, All Rights Reserved
+ * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scorbit.io, All Rights Reserved
  *
  * MIT License
  *

--- a/source/heartbeat.cpp
+++ b/source/heartbeat.cpp
@@ -1,7 +1,7 @@
 /*
  * Scorbit SDK
  *
- * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scrobit.io, All Rights Reserved
+ * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scorbit.io, All Rights Reserved
  *
  * MIT License
  *

--- a/source/heartbeat.h
+++ b/source/heartbeat.h
@@ -1,7 +1,7 @@
 /*
  * Scorbit SDK
  *
- * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scrobit.io, All Rights Reserved
+ * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scorbit.io, All Rights Reserved
  *
  * MIT License
  *

--- a/source/http_session_pool.cpp
+++ b/source/http_session_pool.cpp
@@ -1,7 +1,7 @@
 /*
  * Scorbit SDK
  *
- * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scrobit.io, All Rights Reserved
+ * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scorbit.io, All Rights Reserved
  *
  * MIT License
  *

--- a/source/http_session_pool.h
+++ b/source/http_session_pool.h
@@ -1,7 +1,7 @@
 /*
  * Scorbit SDK
  *
- * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scrobit.io, All Rights Reserved
+ * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scorbit.io, All Rights Reserved
  *
  * MIT License
  *

--- a/source/key_resolver.h
+++ b/source/key_resolver.h
@@ -1,7 +1,7 @@
 /*
  * Scorbit SDK
  *
- * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scrobit.io, All Rights Reserved
+ * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scorbit.io, All Rights Reserved
  *
  * MIT License
  *

--- a/source/leaderboard_c.cpp
+++ b/source/leaderboard_c.cpp
@@ -1,7 +1,7 @@
 /*
  * Scorbit SDK
  *
- * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scrobit.io, All Rights Reserved
+ * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scorbit.io, All Rights Reserved
  *
  * MIT License
  *

--- a/source/leaderboard_internal.h
+++ b/source/leaderboard_internal.h
@@ -1,7 +1,7 @@
 /*
  * Scorbit SDK
  *
- * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scrobit.io, All Rights Reserved
+ * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scorbit.io, All Rights Reserved
  *
  * MIT License
  *

--- a/source/log_c.cpp
+++ b/source/log_c.cpp
@@ -1,7 +1,7 @@
 /*
  * Scorbit SDK
  *
- * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scrobit.io, All Rights Reserved
+ * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scorbit.io, All Rights Reserved
  *
  * MIT License
  *

--- a/source/log_c_stub.cpp
+++ b/source/log_c_stub.cpp
@@ -1,7 +1,7 @@
 /*
  * Scorbit SDK
  *
- * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scrobit.io, All Rights Reserved
+ * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scorbit.io, All Rights Reserved
  *
  * MIT License
  *

--- a/source/modes.cpp
+++ b/source/modes.cpp
@@ -1,7 +1,7 @@
 /*
  * Scorbit SDK
  *
- * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scrobit.io, All Rights Reserved
+ * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scorbit.io, All Rights Reserved
  *
  * MIT License
  *

--- a/source/modes.h
+++ b/source/modes.h
@@ -1,7 +1,7 @@
 /*
  * Scorbit SDK
  *
- * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scrobit.io, All Rights Reserved
+ * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scorbit.io, All Rights Reserved
  *
  * MIT License
  *

--- a/source/net.cpp
+++ b/source/net.cpp
@@ -1,7 +1,7 @@
 /*
  * Scorbit SDK
  *
- * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scrobit.io, All Rights Reserved
+ * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scorbit.io, All Rights Reserved
  *
  * MIT License
  *

--- a/source/net.h
+++ b/source/net.h
@@ -1,7 +1,7 @@
 /*
  * Scorbit SDK
  *
- * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scrobit.io, All Rights Reserved
+ * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scorbit.io, All Rights Reserved
  *
  * MIT License
  *

--- a/source/net_base.h
+++ b/source/net_base.h
@@ -1,7 +1,7 @@
 /*
  * Scorbit SDK
  *
- * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scrobit.io, All Rights Reserved
+ * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scorbit.io, All Rights Reserved
  *
  * MIT License
  *

--- a/source/net_util.cpp
+++ b/source/net_util.cpp
@@ -1,7 +1,7 @@
 /*
  * Scorbit SDK
  *
- * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scrobit.io, All Rights Reserved
+ * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scorbit.io, All Rights Reserved
  *
  * MIT License
  *

--- a/source/net_util.h
+++ b/source/net_util.h
@@ -1,7 +1,7 @@
 /*
  * Scorbit SDK
  *
- * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scrobit.io, All Rights Reserved
+ * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scorbit.io, All Rights Reserved
  *
  * MIT License
  *

--- a/source/nfc_tpm_key_resolver.cpp
+++ b/source/nfc_tpm_key_resolver.cpp
@@ -1,7 +1,7 @@
 /*
  * Scorbit SDK
  *
- * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scrobit.io, All Rights Reserved
+ * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scorbit.io, All Rights Reserved
  *
  * MIT License
  *

--- a/source/nfc_tpm_key_resolver.h
+++ b/source/nfc_tpm_key_resolver.h
@@ -1,7 +1,7 @@
 /*
  * Scorbit SDK
  *
- * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scrobit.io, All Rights Reserved
+ * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scorbit.io, All Rights Reserved
  *
  * MIT License
  *

--- a/source/platform_id.h.in
+++ b/source/platform_id.h.in
@@ -1,7 +1,7 @@
 /*
  * Scorbit SDK
  *
- * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scrobit.io, All Rights Reserved
+ * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scorbit.io, All Rights Reserved
  *
  * MIT License
  *

--- a/source/player_profiles_manager.cpp
+++ b/source/player_profiles_manager.cpp
@@ -1,7 +1,7 @@
 /*
  * Scorbit SDK
  *
- * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scrobit.io, All Rights Reserved
+ * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scorbit.io, All Rights Reserved
  *
  * MIT License
  *

--- a/source/player_profiles_manager.h
+++ b/source/player_profiles_manager.h
@@ -1,7 +1,7 @@
 /*
  * Scorbit SDK
  *
- * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scrobit.io, All Rights Reserved
+ * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scorbit.io, All Rights Reserved
  *
  * MIT License
  *

--- a/source/player_state.cpp
+++ b/source/player_state.cpp
@@ -1,7 +1,7 @@
 /*
  * Scorbit SDK
  *
- * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scrobit.io, All Rights Reserved
+ * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scorbit.io, All Rights Reserved
  *
  * MIT License
  *

--- a/source/player_state.h
+++ b/source/player_state.h
@@ -1,7 +1,7 @@
 /*
  * Scorbit SDK
  *
- * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scrobit.io, All Rights Reserved
+ * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scorbit.io, All Rights Reserved
  *
  * MIT License
  *

--- a/source/provisioning_client.cpp
+++ b/source/provisioning_client.cpp
@@ -1,7 +1,7 @@
 /*
  * Scorbit SDK
  *
- * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scrobit.io, All Rights Reserved
+ * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scorbit.io, All Rights Reserved
  *
  * MIT License
  *

--- a/source/provisioning_client.h
+++ b/source/provisioning_client.h
@@ -1,7 +1,7 @@
 /*
  * Scorbit SDK
  *
- * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scrobit.io, All Rights Reserved
+ * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scorbit.io, All Rights Reserved
  *
  * MIT License
  *

--- a/source/safe_multipart.h
+++ b/source/safe_multipart.h
@@ -1,7 +1,7 @@
 /*
  * Scorbit SDK
  *
- * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scrobit.io, All Rights Reserved
+ * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scorbit.io, All Rights Reserved
  *
  * MIT License
  *

--- a/source/session_flags.h
+++ b/source/session_flags.h
@@ -1,7 +1,7 @@
 /*
  * Scorbit SDK
  *
- * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scrobit.io, All Rights Reserved
+ * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scorbit.io, All Rights Reserved
  *
  * MIT License
  *

--- a/source/signer_key_resolver.h
+++ b/source/signer_key_resolver.h
@@ -1,7 +1,7 @@
 /*
  * Scorbit SDK
  *
- * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scrobit.io, All Rights Reserved
+ * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scorbit.io, All Rights Reserved
  *
  * MIT License
  *

--- a/source/signer_types.h
+++ b/source/signer_types.h
@@ -1,7 +1,7 @@
 /*
  * Scorbit SDK
  *
- * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scrobit.io, All Rights Reserved
+ * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scorbit.io, All Rights Reserved
  *
  * MIT License
  *

--- a/source/soft_key_resolver.cpp
+++ b/source/soft_key_resolver.cpp
@@ -1,7 +1,7 @@
 /*
  * Scorbit SDK
  *
- * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scrobit.io, All Rights Reserved
+ * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scorbit.io, All Rights Reserved
  *
  * MIT License
  *

--- a/source/soft_key_resolver.h
+++ b/source/soft_key_resolver.h
@@ -1,7 +1,7 @@
 /*
  * Scorbit SDK
  *
- * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scrobit.io, All Rights Reserved
+ * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scorbit.io, All Rights Reserved
  *
  * MIT License
  *

--- a/source/updater.cpp
+++ b/source/updater.cpp
@@ -1,7 +1,7 @@
 /*
  * Scorbit SDK
  *
- * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scrobit.io, All Rights Reserved
+ * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scorbit.io, All Rights Reserved
  *
  * MIT License
  *

--- a/source/updater.h
+++ b/source/updater.h
@@ -1,7 +1,7 @@
 /*
  * Scorbit SDK
  *
- * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scrobit.io, All Rights Reserved
+ * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scorbit.io, All Rights Reserved
  *
  * MIT License
  *

--- a/source/utils/archiver.cpp
+++ b/source/utils/archiver.cpp
@@ -1,7 +1,7 @@
 /*
  * Scorbit SDK
  *
- * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scrobit.io, All Rights Reserved
+ * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scorbit.io, All Rights Reserved
  *
  * MIT License
  *

--- a/source/utils/archiver.h
+++ b/source/utils/archiver.h
@@ -1,7 +1,7 @@
 /*
  * Scorbit SDK
  *
- * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scrobit.io, All Rights Reserved
+ * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scorbit.io, All Rights Reserved
  *
  * MIT License
  *

--- a/source/utils/date_time_parser.cpp
+++ b/source/utils/date_time_parser.cpp
@@ -1,7 +1,7 @@
 /*
  * Scorbit SDK
  *
- * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scrobit.io, All Rights Reserved
+ * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scorbit.io, All Rights Reserved
  *
  * MIT License
  *

--- a/source/utils/date_time_parser.h
+++ b/source/utils/date_time_parser.h
@@ -1,7 +1,7 @@
 /*
  * Scorbit SDK
  *
- * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scrobit.io, All Rights Reserved
+ * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scorbit.io, All Rights Reserved
  *
  * MIT License
  *

--- a/source/utils/decrypt.cpp
+++ b/source/utils/decrypt.cpp
@@ -1,7 +1,7 @@
 /*
  * Scorbit SDK
  *
- * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scrobit.io, All Rights Reserved
+ * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scorbit.io, All Rights Reserved
  *
  * MIT License
  *

--- a/source/utils/decrypt.h
+++ b/source/utils/decrypt.h
@@ -1,7 +1,7 @@
 /*
  * Scorbit SDK
  *
- * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scrobit.io, All Rights Reserved
+ * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scorbit.io, All Rights Reserved
  *
  * MIT License
  *

--- a/source/utils/jwt_parser.cpp
+++ b/source/utils/jwt_parser.cpp
@@ -1,7 +1,7 @@
 /*
  * Scorbit SDK
  *
- * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scrobit.io, All Rights Reserved
+ * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scorbit.io, All Rights Reserved
  *
  * MIT License
  *

--- a/source/utils/jwt_parser.h
+++ b/source/utils/jwt_parser.h
@@ -1,7 +1,7 @@
 /*
  * Scorbit SDK
  *
- * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scrobit.io, All Rights Reserved
+ * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scorbit.io, All Rights Reserved
  *
  * MIT License
  *

--- a/source/utils/lan_ip.cpp
+++ b/source/utils/lan_ip.cpp
@@ -1,7 +1,7 @@
 /*
  * Scorbit SDK
  *
- * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scrobit.io, All Rights Reserved
+ * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scorbit.io, All Rights Reserved
  *
  * MIT License
  *

--- a/source/utils/lan_ip.h
+++ b/source/utils/lan_ip.h
@@ -1,7 +1,7 @@
 /*
  * Scorbit SDK
  *
- * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scrobit.io, All Rights Reserved
+ * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scorbit.io, All Rights Reserved
  *
  * MIT License
  *

--- a/source/utils/lru_cache.hpp
+++ b/source/utils/lru_cache.hpp
@@ -1,7 +1,7 @@
 /*
  * Scorbit SDK
  *
- * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scrobit.io, All Rights Reserved
+ * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scorbit.io, All Rights Reserved
  *
  * MIT License
  *

--- a/source/utils/mac_address.cpp
+++ b/source/utils/mac_address.cpp
@@ -1,7 +1,7 @@
 /*
  * Scorbit SDK
  *
- * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scrobit.io, All Rights Reserved
+ * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scorbit.io, All Rights Reserved
  *
  * MIT License
  *

--- a/source/utils/mac_address.h
+++ b/source/utils/mac_address.h
@@ -1,7 +1,7 @@
 /*
  * Scorbit SDK
  *
- * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scrobit.io, All Rights Reserved
+ * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scorbit.io, All Rights Reserved
  *
  * MIT License
  *

--- a/source/utils/machine_fingerprint.cpp
+++ b/source/utils/machine_fingerprint.cpp
@@ -1,7 +1,7 @@
 /*
  * Scorbit SDK
  *
- * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scrobit.io, All Rights Reserved
+ * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scorbit.io, All Rights Reserved
  *
  * MIT License
  *

--- a/source/utils/machine_fingerprint.h
+++ b/source/utils/machine_fingerprint.h
@@ -1,7 +1,7 @@
 /*
  * Scorbit SDK
  *
- * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scrobit.io, All Rights Reserved
+ * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scorbit.io, All Rights Reserved
  *
  * MIT License
  *

--- a/source/utils/thread_priority.cpp
+++ b/source/utils/thread_priority.cpp
@@ -1,7 +1,7 @@
 /*
  * Scorbit SDK
  *
- * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scrobit.io, All Rights Reserved
+ * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scorbit.io, All Rights Reserved
  *
  * MIT License
  *

--- a/source/utils/thread_priority.h
+++ b/source/utils/thread_priority.h
@@ -1,7 +1,7 @@
 /*
  * Scorbit SDK
  *
- * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scrobit.io, All Rights Reserved
+ * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scorbit.io, All Rights Reserved
  *
  * MIT License
  *

--- a/source/worker.cpp
+++ b/source/worker.cpp
@@ -1,7 +1,7 @@
 /*
  * Scorbit SDK
  *
- * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scrobit.io, All Rights Reserved
+ * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scorbit.io, All Rights Reserved
  *
  * MIT License
  *

--- a/source/worker.h
+++ b/source/worker.h
@@ -1,7 +1,7 @@
 /*
  * Scorbit SDK
  *
- * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scrobit.io, All Rights Reserved
+ * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scorbit.io, All Rights Reserved
  *
  * MIT License
  *

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Scorbit SDK
 #
-# (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scrobit.io, All Rights Reserved
+# (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scorbit.io, All Rights Reserved
 #
 # MIT License
 #

--- a/tests/test_detail/CMakeLists.txt
+++ b/tests/test_detail/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Scorbit SDK
 #
-# (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scrobit.io, All Rights Reserved
+# (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scorbit.io, All Rights Reserved
 #
 # MIT License
 #

--- a/tests/test_detail/source/platform_id.h
+++ b/tests/test_detail/source/platform_id.h
@@ -1,7 +1,7 @@
 /*
  * Scorbit SDK
  *
- * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scrobit.io, All Rights Reserved
+ * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scorbit.io, All Rights Reserved
  *
  * MIT License
  *

--- a/tests/test_detail/source/scorbit_sdk/version.h
+++ b/tests/test_detail/source/scorbit_sdk/version.h
@@ -1,7 +1,7 @@
 /*
  * Scorbit SDK
  *
- * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scrobit.io, All Rights Reserved
+ * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scorbit.io, All Rights Reserved
  *
  * MIT License
  *

--- a/tests/test_detail/source/test_archiver.cpp
+++ b/tests/test_detail/source/test_archiver.cpp
@@ -1,7 +1,7 @@
 /*
  * Scorbit SDK
  *
- * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scrobit.io, All Rights Reserved
+ * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scorbit.io, All Rights Reserved
  *
  * MIT License
  *

--- a/tests/test_detail/source/test_date_time_parser.cpp
+++ b/tests/test_detail/source/test_date_time_parser.cpp
@@ -1,7 +1,7 @@
 /*
  * Scorbit SDK
  *
- * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scrobit.io, All Rights Reserved
+ * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scorbit.io, All Rights Reserved
  *
  * MIT License
  *

--- a/tests/test_detail/source/test_decrypt.cpp
+++ b/tests/test_detail/source/test_decrypt.cpp
@@ -1,7 +1,7 @@
 /*
  * Scorbit SDK
  *
- * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scrobit.io, All Rights Reserved
+ * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scorbit.io, All Rights Reserved
  *
  * MIT License
  *

--- a/tests/test_detail/source/test_event_manager.cpp
+++ b/tests/test_detail/source/test_event_manager.cpp
@@ -1,7 +1,7 @@
 /*
  * Scorbit SDK
  *
- * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scrobit.io, All Rights Reserved
+ * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scorbit.io, All Rights Reserved
  *
  * MIT License
  *

--- a/tests/test_detail/source/test_event_queue.cpp
+++ b/tests/test_detail/source/test_event_queue.cpp
@@ -1,7 +1,7 @@
 /*
  * Scorbit SDK
  *
- * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scrobit.io, All Rights Reserved
+ * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scorbit.io, All Rights Reserved
  *
  * MIT License
  *

--- a/tests/test_detail/source/test_game_state.cpp
+++ b/tests/test_detail/source/test_game_state.cpp
@@ -1,7 +1,7 @@
 /*
  * Scorbit SDK
  *
- * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scrobit.io, All Rights Reserved
+ * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scorbit.io, All Rights Reserved
  *
  * MIT License
  *

--- a/tests/test_detail/source/test_heartbeat.cpp
+++ b/tests/test_detail/source/test_heartbeat.cpp
@@ -1,7 +1,7 @@
 /*
  * Scorbit SDK
  *
- * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scrobit.io, All Rights Reserved
+ * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scorbit.io, All Rights Reserved
  *
  * MIT License
  *

--- a/tests/test_detail/source/test_http_session_pool.cpp
+++ b/tests/test_detail/source/test_http_session_pool.cpp
@@ -1,7 +1,7 @@
 /*
  * Scorbit SDK
  *
- * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scrobit.io, All Rights Reserved
+ * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scorbit.io, All Rights Reserved
  *
  * MIT License
  *

--- a/tests/test_detail/source/test_jwt_parser.cpp
+++ b/tests/test_detail/source/test_jwt_parser.cpp
@@ -1,7 +1,7 @@
 /*
  * Scorbit SDK
  *
- * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scrobit.io, All Rights Reserved
+ * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scorbit.io, All Rights Reserved
  *
  * MIT License
  *

--- a/tests/test_detail/source/test_lan_ip.cpp
+++ b/tests/test_detail/source/test_lan_ip.cpp
@@ -1,7 +1,7 @@
 /*
  * Scorbit SDK
  *
- * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scrobit.io, All Rights Reserved
+ * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scorbit.io, All Rights Reserved
  *
  * MIT License
  *

--- a/tests/test_detail/source/test_leaderboard.cpp
+++ b/tests/test_detail/source/test_leaderboard.cpp
@@ -1,7 +1,7 @@
 /*
  * Scorbit SDK
  *
- * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scrobit.io, All Rights Reserved
+ * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scorbit.io, All Rights Reserved
  *
  * MIT License
  *

--- a/tests/test_detail/source/test_logger.cpp
+++ b/tests/test_detail/source/test_logger.cpp
@@ -1,7 +1,7 @@
 /*
  * Scorbit SDK
  *
- * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scrobit.io, All Rights Reserved
+ * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scorbit.io, All Rights Reserved
  *
  * MIT License
  *

--- a/tests/test_detail/source/test_lru_cache.cpp
+++ b/tests/test_detail/source/test_lru_cache.cpp
@@ -1,7 +1,7 @@
 /*
  * Scorbit SDK
  *
- * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scrobit.io, All Rights Reserved
+ * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scorbit.io, All Rights Reserved
  *
  * MIT License
  *

--- a/tests/test_detail/source/test_mac_address.cpp
+++ b/tests/test_detail/source/test_mac_address.cpp
@@ -1,7 +1,7 @@
 /*
  * Scorbit SDK
  *
- * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scrobit.io, All Rights Reserved
+ * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scorbit.io, All Rights Reserved
  *
  * MIT License
  *

--- a/tests/test_detail/source/test_machine_fingerprint.cpp
+++ b/tests/test_detail/source/test_machine_fingerprint.cpp
@@ -1,7 +1,7 @@
 /*
  * Scorbit SDK
  *
- * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scrobit.io, All Rights Reserved
+ * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scorbit.io, All Rights Reserved
  *
  * MIT License
  *

--- a/tests/test_detail/source/test_modes.cpp
+++ b/tests/test_detail/source/test_modes.cpp
@@ -1,7 +1,7 @@
 /*
  * Scorbit SDK
  *
- * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scrobit.io, All Rights Reserved
+ * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scorbit.io, All Rights Reserved
  *
  * MIT License
  *

--- a/tests/test_detail/source/test_net.cpp
+++ b/tests/test_detail/source/test_net.cpp
@@ -1,7 +1,7 @@
 /*
  * Scorbit SDK
  *
- * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scrobit.io, All Rights Reserved
+ * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scorbit.io, All Rights Reserved
  *
  * MIT License
  *

--- a/tests/test_detail/source/test_net_util.cpp
+++ b/tests/test_detail/source/test_net_util.cpp
@@ -1,7 +1,7 @@
 /*
  * Scorbit SDK
  *
- * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scrobit.io, All Rights Reserved
+ * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scorbit.io, All Rights Reserved
  *
  * MIT License
  *

--- a/tests/test_detail/source/test_nfc_tpm_key_resolver.cpp
+++ b/tests/test_detail/source/test_nfc_tpm_key_resolver.cpp
@@ -1,7 +1,7 @@
 /*
  * Scorbit SDK
  *
- * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scrobit.io, All Rights Reserved
+ * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scorbit.io, All Rights Reserved
  *
  * MIT License
  *

--- a/tests/test_detail/source/test_player_profiles_manager.cpp
+++ b/tests/test_detail/source/test_player_profiles_manager.cpp
@@ -1,7 +1,7 @@
 /*
  * Scorbit SDK
  *
- * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scrobit.io, All Rights Reserved
+ * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scorbit.io, All Rights Reserved
  *
  * MIT License
  *

--- a/tests/test_detail/source/test_player_state.cpp
+++ b/tests/test_detail/source/test_player_state.cpp
@@ -1,7 +1,7 @@
 /*
  * Scorbit SDK
  *
- * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scrobit.io, All Rights Reserved
+ * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scorbit.io, All Rights Reserved
  *
  * MIT License
  *

--- a/tests/test_detail/source/test_safe_multipart.cpp
+++ b/tests/test_detail/source/test_safe_multipart.cpp
@@ -1,7 +1,7 @@
 /*
  * Scorbit SDK
  *
- * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scrobit.io, All Rights Reserved
+ * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scorbit.io, All Rights Reserved
  *
  * MIT License
  *

--- a/tests/test_detail/source/test_soft_key_resolver.cpp
+++ b/tests/test_detail/source/test_soft_key_resolver.cpp
@@ -1,7 +1,7 @@
 /*
  * Scorbit SDK
  *
- * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scrobit.io, All Rights Reserved
+ * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scorbit.io, All Rights Reserved
  *
  * MIT License
  *

--- a/tests/test_detail/source/test_updater.cpp
+++ b/tests/test_detail/source/test_updater.cpp
@@ -1,7 +1,7 @@
 /*
  * Scorbit SDK
  *
- * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scrobit.io, All Rights Reserved
+ * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scorbit.io, All Rights Reserved
  *
  * MIT License
  *

--- a/tests/test_detail/source/test_worker.cpp
+++ b/tests/test_detail/source/test_worker.cpp
@@ -1,7 +1,7 @@
 /*
  * Scorbit SDK
  *
- * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scrobit.io, All Rights Reserved
+ * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scorbit.io, All Rights Reserved
  *
  * MIT License
  *

--- a/tests/test_detail/source/trompeloeil_printer.h
+++ b/tests/test_detail/source/trompeloeil_printer.h
@@ -1,7 +1,7 @@
 /*
  * Scorbit SDK
  *
- * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scrobit.io, All Rights Reserved
+ * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scorbit.io, All Rights Reserved
  *
  * MIT License
  *

--- a/tests/test_interface/CMakeLists.txt
+++ b/tests/test_interface/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Scorbit SDK
 #
-# (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scrobit.io, All Rights Reserved
+# (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scorbit.io, All Rights Reserved
 #
 # MIT License
 #

--- a/tests/test_interface/source/test_device_info.cpp
+++ b/tests/test_interface/source/test_device_info.cpp
@@ -1,7 +1,7 @@
 /*
  * Scorbit SDK
  *
- * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scrobit.io, All Rights Reserved
+ * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scorbit.io, All Rights Reserved
  *
  * MIT License
  *

--- a/tests/test_interface/source/test_game_state_c.cpp
+++ b/tests/test_interface/source/test_game_state_c.cpp
@@ -1,7 +1,7 @@
 /*
  * Scorbit SDK
  *
- * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scrobit.io, All Rights Reserved
+ * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scorbit.io, All Rights Reserved
  *
  * MIT License
  *

--- a/tests/test_interface/source/test_version.cpp
+++ b/tests/test_interface/source/test_version.cpp
@@ -1,7 +1,7 @@
 /*
  * Scorbit SDK
  *
- * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scrobit.io, All Rights Reserved
+ * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scorbit.io, All Rights Reserved
  *
  * MIT License
  *

--- a/tests/test_interface_c/CMakeLists.txt
+++ b/tests/test_interface_c/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Scorbit SDK
 #
-# (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scrobit.io, All Rights Reserved
+# (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scorbit.io, All Rights Reserved
 #
 # MIT License
 #

--- a/tests/test_interface_c/source/test_log_c.c
+++ b/tests/test_interface_c/source/test_log_c.c
@@ -1,7 +1,7 @@
 /*
  * Scorbit SDK
  *
- * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scrobit.io, All Rights Reserved
+ * (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scorbit.io, All Rights Reserved
  *
  * MIT License
  *

--- a/tests/test_python/test_scrobit.py
+++ b/tests/test_python/test_scrobit.py
@@ -1,6 +1,6 @@
 # Scorbit SDK
 #
-# (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scrobit.io, All Rights Reserved
+# (c) 2025 Spinner Systems, Inc. (DBA Scorbit), scorbit.io, All Rights Reserved
 #
 # MIT License
 #


### PR DESCRIPTION
## Why

The copyright headers transpose two letters in the domain: `scrobit.io` instead of `scorbit.io`. It appears in 159 files.

Surfaced while auditing licensing in `scorbitd`, which had the same typo in 88 files (scorbit-io/scorbitd#135).

## What changed

Mechanical `scrobit.io` → `scorbit.io` across 159 files. Comment text only — no code, no build files, no behavior.

## Explicitly NOT changed

**`LICENSE` is untouched. scorbit_sdk remains MIT.** The SDK is intentionally open; only scorbitd is proprietary. Verified the diff contains no `LICENSE` change.

## Verification

- 158 files changed, all comment-only
- `git diff --name-only | grep LICENSE` → empty